### PR TITLE
V0.2.0

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -1,0 +1,62 @@
+name: Helm chart validation
+
+on:
+  pull_request:
+    paths:
+      - 'helm/fume/**'
+      - '.github/workflows/helm-validate.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect chart changes and enforce version bump
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHART_DIR=helm/fume
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          echo "Base SHA: $BASE_SHA"
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- "$CHART_DIR" | tr -d '\r')
+          if [ -z "$CHANGED" ]; then
+            echo "No changes under $CHART_DIR."
+            exit 0
+          fi
+          echo "Changed files under $CHART_DIR:"
+          echo "$CHANGED"
+
+          # Require Chart.yaml change when any other chart files changed
+          if echo "$CHANGED" | grep -v -E '^helm/fume/Chart.yaml$' >/dev/null; then
+            if ! echo "$CHANGED" | grep -E '^helm/fume/Chart.yaml$' >/dev/null; then
+              echo "::error::Chart.yaml version must be bumped when chart files change."
+              exit 1
+            fi
+          fi
+
+          # Compare chart versions
+          OLD_VERSION=$(git show "$BASE_SHA:$CHART_DIR/Chart.yaml" | sed -n 's/^version:[[:space:]]*\(.*\)/\1/p' | tr -d '"' | tr -d "\r")
+          NEW_VERSION=$(sed -n 's/^version:[[:space:]]*\(.*\)/\1/p' "$CHART_DIR/Chart.yaml" | tr -d '"' | tr -d "\r")
+          echo "Old chart version: $OLD_VERSION"
+          echo "New chart version: $NEW_VERSION"
+          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+            echo "::error::Chart version not bumped (still $NEW_VERSION)."
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$OLD_VERSION" "$NEW_VERSION" | sort -V | tail -n1)" != "$NEW_VERSION" ]; then
+            echo "::error::New chart version ($NEW_VERSION) must be greater than old version ($OLD_VERSION)."
+            exit 1
+          fi
+
+      - name: Disallow latest image tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -RIN --include 'values*.yaml' -E '(^|[:"[:space:]])latest(["[:space:]]|$)' helm/fume; then
+            echo "::error::Found usage of latest tag in values files. Pin to a specific version or digest."
+            exit 1
+          fi

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME application
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "1.7.1"
 maintainers:
   - name: Outburn Ltd.

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,12 +2,14 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME application
 type: application
-version: 0.1.0
-appVersion: "1.0.0"
+version: 0.1.1
+appVersion: "1.7.1"
 maintainers:
-  - name: FUME Team
+  - name: Outburn Ltd.
 keywords:
   - fume
   - fhir
+  - mapping
   - healthcare
+  - converter
 home: https://github.com/Outburn-IL/fume-deployments

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -61,14 +61,14 @@ kubectl create secret generic fume-secrets \
 # Deploy with frontend enabled (development/testing)
 helm install fume ./helm/fume \
   --namespace fume \
-  --set configMap.CANONICAL_BASE_URL="https://your-fhir-server.com" \
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
   --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
 
 # Deploy for production (frontend disabled)
 helm install fume ./helm/fume \
   -f ./helm/fume/values.prod.yaml \
   --namespace fume \
-  --set configMap.CANONICAL_BASE_URL="https://your-fhir-server.com" \
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
   --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
 ```
 
@@ -240,7 +240,8 @@ helm install fume-dev ./helm/fume \
   --set storage.snapshots.size=5Gi \
   --set env.FUME_DESIGNER_HEADLINE="FUME Designer - DEV" \
   --set configMap.FUME_SERVER_URL="http://localhost:42420" \
-  --set configMap.CANONICAL_BASE_URL="https://fhir-dev.company.com"
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
 ```
 
 ### Test Environment
@@ -255,7 +256,7 @@ helm install fume-test ./helm/fume \
   --set enableFrontend=true \
   --set env.FUME_DESIGNER_HEADLINE="FUME Designer - TEST" \
   --set configMap.FUME_SERVER_URL="https://fume-api-test.company.com" \
-  --set configMap.CANONICAL_BASE_URL="https://fhir-test.company.com" \
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
   --set env.FHIR_SERVER_AUTH_TYPE="BASIC"
 ```
 
@@ -269,7 +270,8 @@ helm install fume-prod ./helm/fume \
   --set image.backend.tag=1.7.1 \
   --set image.frontend.tag=2.1.3 \
   --set configMap.FUME_SERVER_URL="https://fume-api.company.com" \
-  --set configMap.CANONICAL_BASE_URL="https://fhir.company.com"
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
 ```
 
 ### FHIR Server Integration Examples
@@ -309,7 +311,7 @@ env:
 **Required ConfigMap values** (must be provided during deployment):
 ```bash
 # These values MUST be set when installing the chart
---set configMap.CANONICAL_BASE_URL="https://fhir.company.com" \
+--set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
 --set configMap.FHIR_PACKAGES="il.core.fhir.r4@0.17.5,fhir.tx.support.r4,fume.outburn.r4@0.1.0"
 ```
 

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -357,6 +357,33 @@ Common FHIR packages:
 - `us.core` - US Core profiles
 - `hl7.fhir.us.mcode` - Minimal Common Oncology Data Elements
 
+### Version tracking labels
+
+The chart adds labels that allow tracking what is deployed:
+- helm.sh/chart: <chart>-<version>
+- app.kubernetes.io/version: Chart appVersion (backend release)
+- app.kubernetes.io/component: backend | frontend
+- app.kubernetes.io/component-version: container image tag for the component
+- fume.outburn.dev/image: full image reference (repo:tag)
+- fume.outburn.dev/tag: container image tag
+- app.kubernetes.io/name, app.kubernetes.io/instance, app.kubernetes.io/managed-by
+
+Examples to query deployed versions:
+
+```bash
+# Backend image and tag (Deployment labels)
+kubectl -n fume get deploy fume-backend \
+  -o jsonpath='{.metadata.labels.fume\.outburn\.dev/image}{"\n"}{.metadata.labels.app\.kubernetes\.io/component-version}{"\n"}'
+
+# Frontend image and tag (Deployment labels)
+kubectl -n fume get deploy fume-frontend \
+  -o jsonpath='{.metadata.labels.fume\.outburn\.dev/image}{"\n"}{.metadata.labels.app\.kubernetes\.io/component-version}{"\n"}'
+
+# List pods with component and image labels
+kubectl -n fume get pods -l app.kubernetes.io/name=fume \
+  -o custom-columns=NAME:.metadata.name,COMPONENT:.metadata.labels.app\.kubernetes\.io/component,IMAGE:.metadata.labels.fume\.outburn\.dev/image,TAG:.metadata.labels.app\.kubernetes\.io/component-version
+```
+
 #### License File Handling
 
 FUME automatically scans for `*.lic` files in its root directory (`/usr/fume/` for backend, `/usr/fume-designer/` for frontend). The chart mounts the license file with a `.lic` extension, and FUME will:

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -33,19 +33,20 @@ Create the required secrets and ConfigMaps before deploying:
 # Create namespace (optional)
 kubectl create namespace fume
 
-# Create Docker Hub pull secret (REQUIRED - images are private)
+# (Optional) Create Docker Hub pull secret. Only needed if your cluster/namespace/service account
+# does not already provide credentials to pull private images from Docker Hub.
 kubectl create secret docker-registry dockerhub-secret \
   --docker-server=docker.io \
   --docker-username=outburnltd \
-  --docker-password=YOUR_OUTBURN_DOCKERHUB_TOKEN \
+  --docker-password=YOUR_DOCKERHUB_API_TOKEN \
   --namespace fume
 
-# Create the license secret (same file used for both backend and frontend)
+# License secret (mounts only the .lic file via subPath to avoid overlaying app dirs)
 kubectl create secret generic fume-license \
-  --from-file=license.key=./path/to/FUME_Enterprise.lic \
+  --from-file=license.key.lic=./path/to/license.key.lic \
   --namespace fume
 
-# Create application secrets (customize with your values)
+# Application secrets (customize with your values)
 kubectl create secret generic fume-secrets \
   --from-literal=FHIR_SERVER_BASE="https://your-fhir-server.com/fhir" \
   --from-literal=FHIR_SERVER_UN="your-fhir-username" \
@@ -55,7 +56,7 @@ kubectl create secret generic fume-secrets \
 
 ### 2. Deploy with Default Settings
 
-**Important**: You must provide required configuration values during deployment.
+Important: You must provide required configuration values during deployment.
 
 ```bash
 # Deploy with frontend enabled (development/testing)
@@ -78,7 +79,7 @@ helm install fume ./helm/fume \
 
 ### Image Configuration
 
-Update the image settings in `values.yaml` or via command line:
+Update the image settings in `values.yaml` (or override in `values.prod.yaml`) or via command line:
 
 ```yaml
 image:
@@ -89,14 +90,17 @@ image:
     repository: outburnltd/fume-designer           # Private Docker Hub repository  
     tag: "2.1.3"
   pullPolicy: IfNotPresent
-  pullSecret: "dockerhub-secret"  # REQUIRED: Docker Hub credentials
+  pullSecret: "dockerhub-secret"  # Optional: set if your cluster/namespace doesn't already provide pull credentials
 ```
 
-**Important**: The FUME images are hosted as private repositories on Docker Hub. You must:
-1. Receive Docker Hub API token from Outburn via secure channel
-2. Create the `dockerhub-secret` as shown in the setup section
-3. Ensure the secret name matches the `image.pullSecret` value
-4. Avoid using the `latest` tag; pin a specific version or digest
+Important: The FUME images are hosted as private repositories on Docker Hub. Ensure your cluster can pull them by either:
+- Preconfiguring image pull credentials at the namespace/service account or cluster level (e.g., imagePullSecrets on the default ServiceAccount), or
+- Setting `image.pullSecret` and creating the secret as shown below.
+
+Notes:
+- Username is always `outburnltd` (fixed)
+- Password is the Docker Hub API token you'll receive from Outburn via secure channel
+- Avoid using the `latest` tag; pin a specific version or digest
 
 ### Enable/Disable Frontend
 
@@ -146,12 +150,12 @@ frontend:
 
 ## Secrets and License Setup
 
-### Required Secrets
+### Secrets and Image Pull Access
 
-The chart expects three secrets to be created externally:
+The chart expects the following to exist (some created externally):
 
-#### 1. Docker Hub Pull Secret (`dockerhub-secret`)
-**REQUIRED**: FUME images are private on Docker Hub:
+#### 1. Docker Hub Pull Secret (`dockerhub-secret`) — Optional
+Only needed if your cluster/namespace/service account does not already provide credentials to pull the private images.
 
 ```bash
 kubectl create secret docker-registry dockerhub-secret \
@@ -161,22 +165,23 @@ kubectl create secret docker-registry dockerhub-secret \
   --namespace fume
 ```
 
-**Note**: 
+Notes:
 - Username is always `outburnltd` (fixed)
 - Password is the Docker Hub API token you'll receive from Outburn via secure channel
+- Set the secret name in `image.pullSecret` if you create it
 
-#### 2. License Secret (`fume-license`)
+#### 2. License Secret (`fume-license`) — Required
 Contains the FUME Enterprise license file (same file for both backend and frontend):
 
 ```bash
 kubectl create secret generic fume-license \
-  --from-file=license.key=./FUME_Enterprise.lic \
+  --from-file=license.key.lic=./FUME_Enterprise.lic \
   --namespace fume
 ```
 
 *Note: FUME automatically scans for `*.lic` files in the root directory, so the exact filename doesn't matter as long as it has a `.lic` extension.*
 
-#### 3. Application Secrets (`fume-secrets`)
+#### 3. Application Secrets (`fume-secrets`) — Required
 Contains sensitive FHIR server configuration:
 
 ```bash
@@ -187,9 +192,9 @@ kubectl create secret generic fume-secrets \
   --namespace fume
 ```
 
-### Custom Secret Names
+### image.pullSecret
 
-If you need to use different secret names, update `values.yaml`:
+Optional; only required if your cluster doesn’t already have access.
 
 ```yaml
 secrets:
@@ -303,7 +308,7 @@ env:
 
 #### Backend (FUME Engine) Configuration
 
-Non-secret environment variables in `values.yaml`:
+Non-secret environment variables (in `values.yaml`; override in `values.prod.yaml`):
 ```yaml
 env:
   SERVER_PORT: "42420"           # Port the engine exposes (default: 42420)
@@ -329,7 +334,7 @@ kubectl create secret generic fume-secrets \
 
 #### Frontend (FUME Designer) Configuration
 
-Non-secret environment variables in `values.yaml`:
+Non-secret environment variables (in `values.yaml`; override in `values.prod.yaml`):
 ```yaml
 env:
   FUME_DESIGNER_HEADLINE: "FUME Designer - DEV"  # Page title/environment indicator
@@ -542,12 +547,15 @@ kubectl port-forward svc/fume-frontend 3000:3000 --namespace fume
 
 #### 4. Image Pull Issues
 ```bash
-# Check if Docker Hub secret is configured and valid
+# Check if Docker Hub secret is configured and valid (if you created one)
 kubectl get secret dockerhub-secret --namespace fume
 kubectl describe secret dockerhub-secret --namespace fume
 
-# Verify secret is properly referenced in deployment
+# Verify secret is properly referenced in deployment (if using image.pullSecret)
 kubectl describe deployment fume-backend --namespace fume | grep -A5 "Image Pull Secrets"
+
+# If relying on namespace/service account level credentials, check imagePullSecrets there
+kubectl get serviceaccount default -n fume -o yaml | grep -A3 imagePullSecrets
 
 # Check pod events for image pull errors
 kubectl describe pod -l app.kubernetes.io/name=fume --namespace fume
@@ -590,7 +598,9 @@ helm uninstall fume --namespace fume
 kubectl delete pvc --all --namespace fume
 
 # Remove secrets (if no longer needed)
-kubectl delete secret fume-license fume-secrets dockerhub-secret --namespace fume
+kubectl delete secret fume-license fume-secrets --namespace fume
+# If you created a Docker Hub pull secret for this namespace, remove it as well
+kubectl delete secret dockerhub-secret --namespace fume
 
 # Remove namespace (optional)
 kubectl delete namespace fume

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -62,14 +62,16 @@ kubectl create secret generic fume-secrets \
 helm install fume ./helm/fume \
   --namespace fume \
   --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
-  --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
+  --set configMap.FUME_SERVER_URL="https://your-fume-api.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
 
 # Deploy for production (frontend disabled)
 helm install fume ./helm/fume \
   -f ./helm/fume/values.prod.yaml \
   --namespace fume \
   --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
-  --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
+  --set configMap.FUME_SERVER_URL="https://your-fume-api.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
 ```
 
 ## Configuration
@@ -257,6 +259,7 @@ helm install fume-test ./helm/fume \
   --set env.FUME_DESIGNER_HEADLINE="FUME Designer - TEST" \
   --set configMap.FUME_SERVER_URL="https://fume-api-test.company.com" \
   --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>" \
   --set env.FHIR_SERVER_AUTH_TYPE="BASIC"
 ```
 
@@ -312,7 +315,7 @@ env:
 ```bash
 # These values MUST be set when installing the chart
 --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
---set configMap.FHIR_PACKAGES="il.core.fhir.r4@0.17.5,fhir.tx.support.r4,fume.outburn.r4@0.1.0"
+--set configMap.FHIR_PACKAGES="<org-specific-packages>"
 ```
 
 Secret environment variables (in `fume-secrets`):
@@ -345,19 +348,20 @@ env:
 
 #### FHIR Packages Configuration
 
-FUME can install specific FHIR packages on startup. Configure via ConfigMap:
+FUME installs specific FHIR packages on startup. You must supply the package list for your context (organization/jurisdiction specific). Examples:
 
 ```yaml
 configMap:
-  FHIR_PACKAGES: "il.core.fhir.r4,fhir.tx.support.r4,fume.outburn.r4"
+  FHIR_PACKAGES: "us.core.r4@6.1.0,fhir.tx.support.r4,hl7.fhir.us.mcode@2.1.0"
+# or
+configMap:
+  FHIR_PACKAGES: "il.core.fhir.r4@0.17.5,fhir.tx.support.r4,fume.outburn.r4@0.1.0"
 ```
 
-Common FHIR packages:
-- `il.core.fhir.r4` - Israeli Core FHIR profiles
-- `fhir.tx.support.r4` - Terminology support
-- `fume.outburn.r4` - FUME-specific extensions
-- `us.core` - US Core profiles
-- `hl7.fhir.us.mcode` - Minimal Common Oncology Data Elements
+Notes:
+- Provide a comma-separated list. Versions are optional but recommended (pkg@version).
+- Leave it unset to fail fast with a clear validation error.
+
 
 ### Version tracking labels
 

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -82,10 +82,10 @@ Update the image settings in `values.yaml` or via command line:
 image:
   backend:
     repository: outburnltd/fume-enterprise-server  # Private Docker Hub repository
-    tag: "latest"
+    tag: "1.7.1"
   frontend:
     repository: outburnltd/fume-designer           # Private Docker Hub repository  
-    tag: "latest"
+    tag: "2.1.3"
   pullPolicy: IfNotPresent
   pullSecret: "dockerhub-secret"  # REQUIRED: Docker Hub credentials
 ```
@@ -94,6 +94,7 @@ image:
 1. Receive Docker Hub API token from Outburn via secure channel
 2. Create the `dockerhub-secret` as shown in the setup section
 3. Ensure the secret name matches the `image.pullSecret` value
+4. Avoid using the `latest` tag; pin a specific version or digest
 
 ### Enable/Disable Frontend
 
@@ -234,8 +235,8 @@ Common storage class examples:
 # Use default values with frontend enabled
 helm install fume-dev ./helm/fume \
   --namespace fume-dev \
-  --set image.backend.tag=latest \
-  --set image.frontend.tag=latest \
+  --set image.backend.tag=1.7.1 \
+  --set image.frontend.tag=2.1.3 \
   --set storage.snapshots.size=5Gi \
   --set env.FUME_DESIGNER_HEADLINE="FUME Designer - DEV" \
   --set configMap.FUME_SERVER_URL="http://localhost:42420" \
@@ -248,8 +249,8 @@ helm install fume-dev ./helm/fume \
 # Custom values for testing
 helm install fume-test ./helm/fume \
   --namespace fume-test \
-  --set image.backend.tag=latest \
-  --set image.frontend.tag=latest \
+  --set image.backend.tag=1.7.1 \
+  --set image.frontend.tag=2.1.3 \
   --set backend.replicaCount=2 \
   --set enableFrontend=true \
   --set env.FUME_DESIGNER_HEADLINE="FUME Designer - TEST" \
@@ -265,8 +266,8 @@ helm install fume-test ./helm/fume \
 helm install fume-prod ./helm/fume \
   -f ./helm/fume/values.prod.yaml \
   --namespace fume-prod \
-  --set image.backend.tag=latest \
-  --set image.frontend.tag=latest \
+  --set image.backend.tag=1.7.1 \
+  --set image.frontend.tag=2.1.3 \
   --set configMap.FUME_SERVER_URL="https://fume-api.company.com" \
   --set configMap.CANONICAL_BASE_URL="https://fhir.company.com"
 ```
@@ -444,8 +445,8 @@ probes:
 # Upgrade with new image version
 helm upgrade fume ./helm/fume \
   --namespace fume \
-  --set image.backend.tag=latest \
-  --set image.frontend.tag=latest
+  --set image.backend.tag=1.7.2 \
+  --set image.frontend.tag=2.1.4
 
 # Upgrade with new values file
 helm upgrade fume ./helm/fume \
@@ -519,7 +520,7 @@ kubectl describe deployment fume-backend --namespace fume | grep -A5 "Image Pull
 kubectl describe pod -l app.kubernetes.io/name=fume --namespace fume
 
 # Test Docker Hub connectivity (replace with actual image)
-kubectl run test-pull --image=outburnltd/fume-enterprise-server:latest --image-pull-policy=Always --rm -it --restart=Never --namespace fume
+kubectl run test-pull --image=outburnltd/fume-enterprise-server:1.7.1 --image-pull-policy=Always --rm -it --restart=Never --namespace fume
 ```
 
 ### Logs
@@ -571,8 +572,8 @@ For issues related to:
 
 ## Chart Information
 
-- **Chart Version**: 0.1.0
-- **App Version**: 1.0.0
+- **Chart Version**: 0.1.1
+- **App Version**: 1.7.1
 - **Kubernetes Version**: 1.19+
 - **Helm Version**: 3.2.0+
 

--- a/helm/fume/templates/_helpers.tpl
+++ b/helm/fume/templates/_helpers.tpl
@@ -74,4 +74,10 @@ Validate required configuration values
 {{- if not .Values.configMap.FHIR_PACKAGES }}
 {{- fail "FHIR_PACKAGES is required and must be provided by the deploying organization (context/jurisdiction specific). Example: --set configMap.FHIR_PACKAGES=\"pkg1@x.y.z,pkg2,pkg3@a.b.c\"" }}
 {{- end }}
+{{- if not .Values.secrets.fume }}
+{{- fail "Application secrets name is required. Please ensure you have created the 'fume-secrets' secret or update values.yaml" }}
+{{- end }}
+{{- if not .Values.secrets.license }}
+{{- fail "License secret name is required. Please ensure you have created the 'fume-license' secret or update values.yaml" }}
+{{- end }}
 {{- end }}

--- a/helm/fume/templates/_helpers.tpl
+++ b/helm/fume/templates/_helpers.tpl
@@ -66,9 +66,12 @@ Validate required configuration values
 */}}
 {{- define "fume.validation" -}}
 {{- if not .Values.configMap.CANONICAL_BASE_URL }}
-{{- fail "CANONICAL_BASE_URL is required. Please set it via --set configMap.CANONICAL_BASE_URL=\"https://your-fhir-server.com\"" }}
+{{- fail "CANONICAL_BASE_URL is required. Please set it via --set configMap.CANONICAL_BASE_URL=\"https://fume.your-company.com\"" }}
 {{- end }}
 {{- if not .Values.configMap.FUME_SERVER_URL }}
 {{- fail "FUME_SERVER_URL is required. Please set it via --set configMap.FUME_SERVER_URL=\"https://your-fume-api.com\"" }}
+{{- end }}
+{{- if not .Values.configMap.FHIR_PACKAGES }}
+{{- fail "FHIR_PACKAGES is required and must be provided by the deploying organization (context/jurisdiction specific). Example: --set configMap.FHIR_PACKAGES=\"pkg1@x.y.z,pkg2,pkg3@a.b.c\"" }}
 {{- end }}
 {{- end }}

--- a/helm/fume/templates/_validation.tpl
+++ b/helm/fume/templates/_validation.tpl
@@ -1,18 +1,5 @@
 {{/*
-Validate required configuration values
+Validation is consolidated in the helper template.
+This file now simply invokes the shared validation to retain compatibility if referenced directly.
 */}}
-{{- if not .Values.configMap.CANONICAL_BASE_URL }}
-{{- fail "CANONICAL_BASE_URL is required. Please set it via --set configMap.CANONICAL_BASE_URL=\"https://fume.your-company.com\"" }}
-{{- end }}
-
-{{- if not .Values.configMap.FUME_SERVER_URL }}
-{{- fail "FUME_SERVER_URL is required. Please set it via --set configMap.FUME_SERVER_URL=\"https://your-fume-api.com\"" }}
-{{- end }}
-
-{{- if not .Values.secrets.fume }}
-{{- fail "Application secrets name is required. Please ensure you have created the 'fume-secrets' secret or update values.yaml" }}
-{{- end }}
-
-{{- if not .Values.secrets.license }}
-{{- fail "License secret name is required. Please ensure you have created the 'fume-license' secret or update values.yaml" }}
-{{- end }}
+{{- include "fume.validation" . -}}

--- a/helm/fume/templates/_validation.tpl
+++ b/helm/fume/templates/_validation.tpl
@@ -2,7 +2,7 @@
 Validate required configuration values
 */}}
 {{- if not .Values.configMap.CANONICAL_BASE_URL }}
-{{- fail "CANONICAL_BASE_URL is required. Please set it via --set configMap.CANONICAL_BASE_URL=\"https://your-fhir-server.com\"" }}
+{{- fail "CANONICAL_BASE_URL is required. Please set it via --set configMap.CANONICAL_BASE_URL=\"https://fume.your-company.com\"" }}
 {{- end }}
 
 {{- if not .Values.configMap.FUME_SERVER_URL }}

--- a/helm/fume/templates/_validation.tpl
+++ b/helm/fume/templates/_validation.tpl
@@ -16,7 +16,3 @@ Validate required configuration values
 {{- if not .Values.secrets.license }}
 {{- fail "License secret name is required. Please ensure you have created the 'fume-license' secret or update values.yaml" }}
 {{- end }}
-
-{{- if not .Values.image.pullSecret }}
-{{- fail "Docker Hub pull secret is required. Please create 'dockerhub-secret' or update image.pullSecret in values.yaml" }}
-{{- end }}

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "fume.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
+    fume.outburn.dev/image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+    fume.outburn.dev/tag: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+    app.kubernetes.io/component-version: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
 spec:
   {{- if not .Values.autoscaling.backend.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
@@ -20,6 +23,9 @@ spec:
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
+        fume.outburn.dev/image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+        fume.outburn.dev/tag: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+        app.kubernetes.io/component-version: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -85,8 +85,10 @@ spec:
               mountPath: /usr/fume/snapshots
             - name: templates
               mountPath: /usr/fume/templates
+            # Mount license as a single file
             - name: license
-              mountPath: /usr/fume
+              mountPath: /usr/fume/license.key.lic
+              subPath: license.key.lic
               readOnly: true
       volumes:
         - name: logs
@@ -101,8 +103,8 @@ spec:
           secret:
             secretName: {{ .Values.secrets.license }}
             items:
-              - key: license.key
-                path: FUME_Enterprise.lic
+              - key: license.key.lic
+                path: license.key.lic
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fume/templates/frontend-deployment.yaml
+++ b/helm/fume/templates/frontend-deployment.yaml
@@ -80,8 +80,10 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: /usr/fume-designer/logs
+            # Mount license as a single file to avoid overlaying the app dir
             - name: license
-              mountPath: /usr/fume-designer
+              mountPath: /usr/fume-designer/license.key.lic
+              subPath: license.key.lic
               readOnly: true
       volumes:
         - name: logs
@@ -90,8 +92,8 @@ spec:
           secret:
             secretName: {{ .Values.secrets.license }}
             items:
-              - key: license.key
-                path: FUME_Enterprise.lic
+              - key: license.key.lic
+                path: license.key.lic
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fume/templates/frontend-deployment.yaml
+++ b/helm/fume/templates/frontend-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "fume.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
+    fume.outburn.dev/image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+    fume.outburn.dev/tag: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+    app.kubernetes.io/component-version: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
 spec:
   {{- if not .Values.autoscaling.frontend.enabled }}
   replicas: {{ .Values.frontend.replicaCount }}
@@ -21,6 +24,9 @@ spec:
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
+        fume.outburn.dev/image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+        fume.outburn.dev/tag: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+        app.kubernetes.io/component-version: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/helm/fume/values.prod.yaml
+++ b/helm/fume/values.prod.yaml
@@ -33,8 +33,8 @@ env:
 
 # ConfigMap data for production - override defaults and set required values
 configMap:
-  # CANONICAL_BASE_URL: "https://fhir.production.com"  # REQUIRED: Set during deployment
-  FHIR_PACKAGES: "il.core.fhir.r4,fhir.tx.support.r4,fume.outburn.r4"
+  # CANONICAL_BASE_URL: "https://fume.your-company.com"  # REQUIRED: Set during deployment
+  # FHIR_PACKAGES: ""                                   # REQUIRED: Comma-separated list (org/jurisdiction specific)
   # FUME_SERVER_URL: "https://fume-api.production.com"  # REQUIRED: Set during deployment
 
 # Auto-scaling enabled for production

--- a/helm/fume/values.prod.yaml
+++ b/helm/fume/values.prod.yaml
@@ -4,6 +4,13 @@
 # Disable frontend in production
 enableFrontend: false
 
+# Image pull secret (optional)
+# If your cluster/namespace/service account does not already provide credentials to pull
+# private images from Docker Hub, set the secret name here. Otherwise leave it unset
+# and rely on cluster/namespace/service account level imagePullSecrets.
+# image:
+#   pullSecret: "dockerhub-secret"
+
 # Backend configuration for production
 backend:
   replicaCount: 3

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,10 +13,10 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "latest"
+    tag: "1.7.1"
   frontend:
     repository: outburnltd/fume-designer
-    tag: "latest"
+    tag: "2.1.3"
   pullPolicy: IfNotPresent
   pullSecret: "dockerhub-secret"  # Required for private Docker Hub images
 

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -18,7 +18,7 @@ image:
     repository: outburnltd/fume-designer
     tag: "2.1.3"
   pullPolicy: IfNotPresent
-  pullSecret: "dockerhub-secret"  # Required for private Docker Hub images
+  pullSecret: ""  # Optional: set to a Secret name only if namespace/service account doesn't already provide pull access
 
 # Backend configuration
 backend:

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -105,8 +105,8 @@ serviceAccount:
 
 # Secrets (referenced by name, not created by this chart)
 secrets:
-  fume: "fume-secrets"  # Name of the secret containing sensitive config
-  license: "fume-license"  # Name of the secret containing license.key
+  fume: "fume-secrets"  # Name of the secret containing sensitive config (e.g., FHIR_SERVER_BASE; if BASIC auth: FHIR_SERVER_UN/FHIR_SERVER_PW)
+  license: "fume-license"  # Name of the secret containing the license file; must include key: license.key.lic (must end with .lic)
 
 # Environment variables
 env:
@@ -126,9 +126,9 @@ env:
 # ConfigMap data (non-secret values)
 # Note: Required values must be provided during installation
 configMap:
-  # CANONICAL_BASE_URL: ""  # REQUIRED: Base URL for canonical URLs - set via --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com"
+  # CANONICAL_BASE_URL: ""  # REQUIRED: Unique canonical identifier (typically FQDN) used in FHIR resources, e.g., https://fhir.company.com.
   # FHIR_PACKAGES: ""      # REQUIRED: Comma-separated package list (context-specific) - set via --set configMap.FHIR_PACKAGES="pkg1@x.y.z,pkg2,pkg3@a.b.c"
-  # FUME_SERVER_URL: ""     # REQUIRED: URL for browser to access FUME engine - set via --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
+  # FUME_SERVER_URL: ""     # REQUIRED: Browser-facing URL to the backend; must be reachable from the user's network.
 
 # Liveness and readiness probes
 probes:

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -126,9 +126,8 @@ env:
 # ConfigMap data (non-secret values)
 # Note: Required values must be provided during installation
 configMap:
-  # CANONICAL_BASE_URL: ""  # REQUIRED: Base URL for canonical URLs - set via --set configMap.CANONICAL_BASE_URL="https://your-fhir-server.com"
-  FHIR_PACKAGES: "il.core.fhir.r4,fhir.tx.support.r4,fume.outburn.r4"
-  
+  # CANONICAL_BASE_URL: ""  # REQUIRED: Base URL for canonical URLs - set via --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com"
+  # FHIR_PACKAGES: ""      # REQUIRED: Comma-separated package list (context-specific) - set via --set configMap.FHIR_PACKAGES="pkg1@x.y.z,pkg2,pkg3@a.b.c"
   # FUME_SERVER_URL: ""     # REQUIRED: URL for browser to access FUME engine - set via --set configMap.FUME_SERVER_URL="https://your-fume-api.com"
 
 # Liveness and readiness probes


### PR DESCRIPTION
This PR bumps the FUME Helm chart to version 0.2.0, updating image tags to specific versions and improving configuration management for production deployments.

* Updates chart version from 0.1.0 to 0.2.0 with corresponding app version bump
* Changes image tags from "latest" to specific versions (backend: 1.7.1, frontend: 2.1.3)
* Makes Docker Hub pull secrets optional and improves license file mounting
* Adds comprehensive validation workflow and version tracking labels