### PR TITLE
V0.2.2

### DIFF
--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME application
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.7.1"
 maintainers:
   - name: Outburn Ltd.

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -102,6 +102,53 @@ Notes:
 - Password is the Docker Hub API token you'll receive from Outburn via secure channel
 - Avoid using the `latest` tag; pin a specific version or digest
 
+### TLS and certificate trust (Node.js)
+
+The containers run Node.js clients that must trust your organization's CAs to make outbound HTTPS calls (e.g., to FHIR servers). By default, this chart configures Node.js to trust the Kubernetes ServiceAccount CA by setting `NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+
+You can also mount your own corporate CA bundle (PEM) from a Secret and point Node.js to it.
+
+Defaults (in `values.yaml`):
+
+```yaml
+tls:
+  useServiceAccountCA: true
+  customCA:
+    enabled: false
+    secretName: ""
+    key: ca.crt
+    mountPath: /etc/ssl/custom-ca
+    filename: ca.crt
+```
+
+Use a custom CA bundle (preferred for enterprise networks):
+
+1) Create a Secret that contains your PEM bundle (single file, may contain multiple certs):
+
+```cmd
+kubectl create secret generic custom-ca ^
+  --from-file=ca.crt=corp-root-bundle.pem ^
+  --namespace fume
+```
+
+2) Enable and reference it in values:
+
+```yaml
+tls:
+  useServiceAccountCA: false
+  customCA:
+    enabled: true
+    secretName: custom-ca
+    key: ca.crt
+    mountPath: /etc/ssl/custom-ca
+    filename: ca.crt
+```
+
+Behavior:
+- If `tls.customCA.enabled=true`, the chart mounts the secret and sets `NODE_EXTRA_CA_CERTS` to `<mountPath>/<filename>`.
+- Else if `tls.useServiceAccountCA=true` (default), Node.js trusts the SA CA at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+- No insecure overrides are used. Avoid setting `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
 ### Enable/Disable Frontend
 
 ```yaml
@@ -564,6 +611,20 @@ kubectl describe pod -l app.kubernetes.io/name=fume --namespace fume
 kubectl run test-pull --image=outburnltd/fume-enterprise-server:1.7.1 --image-pull-policy=Always --rm -it --restart=Never --namespace fume
 ```
 
+#### 5. x509 / certificate trust errors
+
+Symptoms: Errors like `x509: certificate signed by unknown authority` when the backend tries to access HTTPS endpoints.
+
+What to check:
+- If your organization uses a custom/corporate CA, create a CA bundle Secret and enable `tls.customCA.enabled=true` (see section above).
+- If using the cluster's ServiceAccount CA, ensure defaults are in effect (`tls.useServiceAccountCA=true`).
+- Verify the PEM file contains only certificates (no private keys).
+- Confirm the environment variable is set in the pod:
+
+```cmd
+kubectl -n fume exec deploy/fume-backend -- printenv NODE_EXTRA_CA_CERTS
+```
+
 ### Logs
 
 ```bash
@@ -616,6 +677,7 @@ For issues related to:
 ## Chart Information
 
 - **Chart Version**: 0.1.1
+ - **Chart Version**: 0.2.2
 - **App Version**: 1.7.1
 - **Kubernetes Version**: 1.19+
 - **Helm Version**: 3.2.0+

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -422,9 +422,17 @@ The chart adds labels that allow tracking what is deployed:
 - app.kubernetes.io/version: Chart appVersion (backend release)
 - app.kubernetes.io/component: backend | frontend
 - app.kubernetes.io/component-version: container image tag for the component
-- fume.outburn.dev/image: full image reference (repo:tag)
-- fume.outburn.dev/tag: container image tag
+- fume.outburn.dev/image: image identifier derived from repo:tag (normalized for label constraints: lowercased; '/' ':' '@' replaced with '-'; may be truncated to 63 chars)
+- fume.outburn.dev/tag: container image tag (normalized for label constraints)
 - app.kubernetes.io/name, app.kubernetes.io/instance, app.kubernetes.io/managed-by
+
+Note: If you need the exact, unsanitized image reference, query the container spec:
+
+```bash
+kubectl -n <ns> get deploy <name> -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+Label namespace note: The `fume.outburn.dev/*` prefix is a custom label namespace based on the Outburn domain. The `.dev` here is part of the domain name, not an indicator of a development environment. These labels are used across all environments (dev/test/prod).
 
 Examples to query deployed versions:
 

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -71,6 +71,14 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            # Ensure Node.js trusts the appropriate CA bundle
+            {{- if .Values.tls.customCA.enabled }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ printf "%s/%s" .Values.tls.customCA.mountPath .Values.tls.customCA.filename }}
+            {{- else if .Values.tls.useServiceAccountCA }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "fume.fullname" . }}-config
@@ -93,6 +101,11 @@ spec:
               mountPath: /usr/fume/license.key.lic
               subPath: license.key.lic
               readOnly: true
+            {{- if .Values.tls.customCA.enabled }}
+            - name: custom-ca
+              mountPath: {{ .Values.tls.customCA.mountPath }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: logs
           emptyDir: {}
@@ -111,6 +124,14 @@ spec:
             items:
               - key: license.key.lic
                 path: license.key.lic
+        {{- if .Values.tls.customCA.enabled }}
+        - name: custom-ca
+          secret:
+            secretName: {{ .Values.tls.customCA.secretName }}
+            items:
+              - key: {{ .Values.tls.customCA.key }}
+                path: {{ .Values.tls.customCA.filename }}
+        {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "fume.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
-    fume.outburn.dev/image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
-    fume.outburn.dev/tag: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
-    app.kubernetes.io/component-version: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+  fume.outburn.dev/image: "{{ include "fume.labelValue" (printf "%s:%s" .Values.image.backend.repository (.Values.image.backend.tag | default .Chart.AppVersion)) }}"
+  fume.outburn.dev/tag: "{{ include "fume.labelValue" (.Values.image.backend.tag | default .Chart.AppVersion) }}"
+  app.kubernetes.io/component-version: "{{ include "fume.labelValue" (.Values.image.backend.tag | default .Chart.AppVersion) }}"
 spec:
   {{- if not .Values.autoscaling.backend.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
@@ -23,9 +23,9 @@ spec:
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
-        fume.outburn.dev/image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
-        fume.outburn.dev/tag: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
-        app.kubernetes.io/component-version: "{{ .Values.image.backend.tag | default .Chart.AppVersion }}"
+  fume.outburn.dev/image: "{{ include "fume.labelValue" (printf "%s:%s" .Values.image.backend.repository (.Values.image.backend.tag | default .Chart.AppVersion)) }}"
+  fume.outburn.dev/tag: "{{ include "fume.labelValue" (.Values.image.backend.tag | default .Chart.AppVersion) }}"
+  app.kubernetes.io/component-version: "{{ include "fume.labelValue" (.Values.image.backend.tag | default .Chart.AppVersion) }}"
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/helm/fume/templates/frontend-deployment.yaml
+++ b/helm/fume/templates/frontend-deployment.yaml
@@ -6,9 +6,9 @@ metadata:
   labels:
     {{- include "fume.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
-    fume.outburn.dev/image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
-    fume.outburn.dev/tag: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
-    app.kubernetes.io/component-version: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+  fume.outburn.dev/image: "{{ include "fume.labelValue" (printf "%s:%s" .Values.image.frontend.repository (.Values.image.frontend.tag | default .Chart.AppVersion)) }}"
+  fume.outburn.dev/tag: "{{ include "fume.labelValue" (.Values.image.frontend.tag | default .Chart.AppVersion) }}"
+  app.kubernetes.io/component-version: "{{ include "fume.labelValue" (.Values.image.frontend.tag | default .Chart.AppVersion) }}"
 spec:
   {{- if not .Values.autoscaling.frontend.enabled }}
   replicas: {{ .Values.frontend.replicaCount }}
@@ -24,9 +24,9 @@ spec:
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
-        fume.outburn.dev/image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
-        fume.outburn.dev/tag: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
-        app.kubernetes.io/component-version: "{{ .Values.image.frontend.tag | default .Chart.AppVersion }}"
+  fume.outburn.dev/image: "{{ include "fume.labelValue" (printf "%s:%s" .Values.image.frontend.repository (.Values.image.frontend.tag | default .Chart.AppVersion)) }}"
+  fume.outburn.dev/tag: "{{ include "fume.labelValue" (.Values.image.frontend.tag | default .Chart.AppVersion) }}"
+  app.kubernetes.io/component-version: "{{ include "fume.labelValue" (.Values.image.frontend.tag | default .Chart.AppVersion) }}"
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/helm/fume/templates/frontend-deployment.yaml
+++ b/helm/fume/templates/frontend-deployment.yaml
@@ -72,6 +72,14 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            # Ensure Node.js trusts the appropriate CA bundle
+            {{- if .Values.tls.customCA.enabled }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ printf "%s/%s" .Values.tls.customCA.mountPath .Values.tls.customCA.filename }}
+            {{- else if .Values.tls.useServiceAccountCA }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "fume.fullname" . }}-config
@@ -85,6 +93,11 @@ spec:
               mountPath: /usr/fume-designer/license.key.lic
               subPath: license.key.lic
               readOnly: true
+            {{- if .Values.tls.customCA.enabled }}
+            - name: custom-ca
+              mountPath: {{ .Values.tls.customCA.mountPath }}
+              readOnly: true
+            {{- end }}
       volumes:
         - name: logs
           emptyDir: {}
@@ -94,6 +107,14 @@ spec:
             items:
               - key: license.key.lic
                 path: license.key.lic
+        {{- if .Values.tls.customCA.enabled }}
+        - name: custom-ca
+          secret:
+            secretName: {{ .Values.tls.customCA.secretName }}
+            items:
+              - key: {{ .Values.tls.customCA.key }}
+                path: {{ .Values.tls.customCA.filename }}
+        {{- end }}
       {{- with .Values.frontend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -130,6 +130,23 @@ configMap:
   # FHIR_PACKAGES: ""      # REQUIRED: Comma-separated package list (context-specific) - set via --set configMap.FHIR_PACKAGES="pkg1@x.y.z,pkg2,pkg3@a.b.c"
   # FUME_SERVER_URL: ""     # REQUIRED: Browser-facing URL to the backend; must be reachable from the user's network.
 
+# TLS/Trust configuration for Node.js clients inside the pods
+# By default, Node.js in the containers will trust the Kubernetes ServiceAccount CA
+# at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt via NODE_EXTRA_CA_CERTS.
+# You can also mount a custom corporate CA bundle from a Secret and point Node.js to it.
+tls:
+  # When true (default), set NODE_EXTRA_CA_CERTS to the service account CA path.
+  useServiceAccountCA: true
+
+  # Optional: mount a Secret containing a PEM bundle (one file) with corporate/internal CAs
+  # and set NODE_EXTRA_CA_CERTS to that file instead of the service account CA.
+  customCA:
+    enabled: false
+    secretName: ""   # Name of the Secret that contains the CA bundle
+    key: ca.crt      # Key in the Secret to mount (must be a single PEM file)
+    mountPath: /etc/ssl/custom-ca  # Where to mount the Secret
+    filename: ca.crt # Filename to give the mounted key
+
 # Liveness and readiness probes
 probes:
   backend:


### PR DESCRIPTION
- inject NODE_EXTRA_CA_CERTS into backend/frontend (defaults to service account CA)
- add tls.useServiceAccountCA (default true) and tls.customCA.* in [values.yaml](vscode-file://vscode-app/c:/Users/DanielMechanik/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- mount custom CA Secret when enabled
- document enterprise CA options and x509 troubleshooting in README
- Add helper fume.labelValue to sanitize label values (lowercase, replace / : @ with -, strip invalid chars, trim edges, truncate to 63)
- Apply normalization to fume.outburn.dev/image, fume.outburn.dev/tag, and app.kubernetes.io/component-version in backend/frontend Deployments
- Update README to document normalization and clarify fume.outburn.dev/* is a domain-based label namespace (not env-specific)