### PR TITLE
fix: bump chart version to 0.4.2 and app version to 1.8.1

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -102,8 +102,11 @@ jobs:
       - name: Install chart (scenario)
         run: |
           set -euo pipefail
+          # Run containers as non-root to reproduce startup failure (no chart change needed)
           COMMON_OVERRIDES="--set image.pullSecret=regcred --set-string env.SERVER_STATELESS=true --set storage.fhirCache.enabled=true --set configMap.FHIR_PACKAGES=hl7.fhir.r4.core@4.0.1 \
-            --set storage.snapshots.storageClass=$STORAGE_CLASS --set storage.templates.storageClass=$STORAGE_CLASS --set storage.fhirCache.storageClass=$STORAGE_CLASS"
+            --set storage.snapshots.storageClass=$STORAGE_CLASS --set storage.templates.storageClass=$STORAGE_CLASS --set storage.fhirCache.storageClass=$STORAGE_CLASS \
+            --set podSecurityContext.runAsUser=65534 --set podSecurityContext.runAsGroup=65534 \
+            --set securityContext.runAsNonRoot=true"
           if [ "${{ matrix.scenario }}" = "default" ]; then
             helm install fume ./helm/fume -n fume \
               $COMMON_OVERRIDES \
@@ -232,3 +235,4 @@ jobs:
         if: always()
         run: |
           kubectl delete ns fume --wait=false || true
+

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 0.4.1
-appVersion: "1.8.0"
+version: 0.4.2
+appVersion: "1.8.1"
 maintainers:
   - name: Outburn Ltd.
 keywords:

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.8.0"
 maintainers:
   - name: Outburn Ltd.

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,7 +13,7 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "1.8.0"  # Backend application version (matches Chart appVersion unless overridden)
+    tag: "1.8.1"  # Backend application version (matches Chart appVersion unless overridden)
   frontend:
     repository: outburnltd/fume-designer
     tag: "2.1.3"


### PR DESCRIPTION
This PR updates the FUME Helm chart to version 0.4.2 with backend application version 1.8.1, and enhances the E2E tests to verify non-root container execution.

- Bumps Helm chart version from 0.4.1 to 0.4.2
- Updates backend application version from 1.8.0 to 1.8.1
- Adds non-root security context testing to the E2E workflow