### PR TITLE
feat: Major refactor of FUME Helm chart for v1.0.0 release

### DIFF
--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -101,8 +101,9 @@ jobs:
           set -euo pipefail
           # Run containers as non-root to reproduce startup failure (no chart change needed)
           COMMON_OVERRIDES="--set image.pullSecret=regcred --set storage.fhirCache.enabled=true --set configMap.FHIR_PACKAGES=hl7.fhir.r4.core@4.0.1 \
+            --set env.FHIR_SERVER_AUTH_TYPE=NONE \
             --set storage.templates.storageClass=$STORAGE_CLASS --set storage.fhirCache.storageClass=$STORAGE_CLASS \
-            --set podSecurityContext.runAsUser=65534 --set podSecurityContext.runAsGroup=65534 \
+            --set podSecurityContext.runAsUser=65534 --set podSecurityContext.runAsGroup=65534 --set podSecurityContext.fsGroup=65534 --set podSecurityContext.fsGroupChangePolicy=OnRootMismatch \
             --set securityContext.runAsNonRoot=true"
           if [ "${{ matrix.scenario }}" = "default" ]; then
             helm install fume ./helm/fume -n fume \
@@ -128,7 +129,15 @@ jobs:
           kubectl -n fume get events --sort-by=.metadata.creationTimestamp | tail -n 40 || true
       - name: Wait for backend rollout
         run: |
-          kubectl -n fume rollout status deployment/fume-backend --timeout=600s
+          set -euo pipefail
+          if ! kubectl -n fume rollout status deployment/fume-backend --timeout=600s; then
+            echo '--- Rollout failed. Deployment + pod diagnostics:'
+            kubectl -n fume describe deployment fume-backend || true
+            kubectl -n fume get pods -l app.kubernetes.io/component=backend -o wide || true
+            kubectl -n fume describe pods -l app.kubernetes.io/component=backend || true
+            kubectl -n fume get events --sort-by=.metadata.creationTimestamp | tail -n 80 || true
+            exit 1
+          fi
       - name: Create curl prober pod
         run: |
           # Lightweight pod with curl for application probing; reused for version polling.

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Wait for backend rollout
         run: |
           set -euo pipefail
-          if ! kubectl -n fume rollout status deployment/fume-backend --timeout=600s; then
+          if ! kubectl -n fume rollout status deployment/fume-backend --timeout=400s; then
             echo '--- Rollout failed. Deployment + pod diagnostics:'
             kubectl -n fume describe deployment fume-backend || true
             kubectl -n fume get pods -l app.kubernetes.io/component=backend -o wide || true

--- a/.github/workflows/helm-e2e.yml
+++ b/.github/workflows/helm-e2e.yml
@@ -69,11 +69,8 @@ jobs:
       - name: Create application secrets (fume-secrets)
         run: |
           # Secret required by chart; validation ensures .Values.secrets.fume exists.
-          # Provide dummy FHIR server values since SERVER_STATELESS=true in CI.
           kubectl -n fume create secret generic fume-secrets \
-            --from-literal=FHIR_SERVER_BASE="https://dummy.fhir.server/fhir" \
-            --from-literal=FHIR_SERVER_UN="dummy-user" \
-            --from-literal=FHIR_SERVER_PW="dummy-pass" || true
+            --from-literal=FHIR_SERVER_BASE="n/a" || true
       - name: Create DockerHub pull secret
         run: |
           kubectl -n fume create secret docker-registry regcred \
@@ -103,8 +100,8 @@ jobs:
         run: |
           set -euo pipefail
           # Run containers as non-root to reproduce startup failure (no chart change needed)
-          COMMON_OVERRIDES="--set image.pullSecret=regcred --set-string env.SERVER_STATELESS=true --set storage.fhirCache.enabled=true --set configMap.FHIR_PACKAGES=hl7.fhir.r4.core@4.0.1 \
-            --set storage.snapshots.storageClass=$STORAGE_CLASS --set storage.templates.storageClass=$STORAGE_CLASS --set storage.fhirCache.storageClass=$STORAGE_CLASS \
+          COMMON_OVERRIDES="--set image.pullSecret=regcred --set storage.fhirCache.enabled=true --set configMap.FHIR_PACKAGES=hl7.fhir.r4.core@4.0.1 \
+            --set storage.templates.storageClass=$STORAGE_CLASS --set storage.fhirCache.storageClass=$STORAGE_CLASS \
             --set podSecurityContext.runAsUser=65534 --set podSecurityContext.runAsGroup=65534 \
             --set securityContext.runAsNonRoot=true"
           if [ "${{ matrix.scenario }}" = "default" ]; then
@@ -115,6 +112,10 @@ jobs:
           else
             helm install fume ./helm/fume -n fume -f ./helm/fume/values.prod.yaml \
               $COMMON_OVERRIDES \
+              --set backend.replicaCount=1 \
+              --set autoscaling.backend.enabled=false \
+              --set storage.templates.accessMode=ReadWriteOnce \
+              --set storage.fhirCache.accessMode=ReadWriteOnce \
               --set configMap.CANONICAL_BASE_URL="https://fume.prod.example.com" \
               --set configMap.FUME_SERVER_URL="https://api.prod.example.com";
           fi
@@ -127,7 +128,7 @@ jobs:
           kubectl -n fume get events --sort-by=.metadata.creationTimestamp | tail -n 40 || true
       - name: Wait for backend rollout
         run: |
-          kubectl -n fume rollout status statefulset/fume-backend --timeout=600s
+          kubectl -n fume rollout status deployment/fume-backend --timeout=600s
       - name: Create curl prober pod
         run: |
           # Lightweight pod with curl for application probing; reused for version polling.
@@ -202,11 +203,12 @@ jobs:
       - name: Check fhirCache folder population
         run: |
           set -euo pipefail
+          POD=$(kubectl -n fume get pods -l app.kubernetes.io/component=backend -o jsonpath='{.items[0].metadata.name}')
           TARGET_DIR='hl7.fhir.r4.core#4.0.1'
           for i in $(seq 1 20); do
-            if kubectl -n fume exec fume-backend-0 -- sh -c "ls -1 /usr/fume/fhir-packages | grep -F '$TARGET_DIR'" >/dev/null 2>&1; then
+            if kubectl -n fume exec "$POD" -- sh -c "ls -1 /usr/fume/fhir-packages | grep -F '$TARGET_DIR'" >/dev/null 2>&1; then
               echo "Found expected FHIR package directory: $TARGET_DIR";
-              kubectl -n fume exec fume-backend-0 -- sh -c "ls -1 /usr/fume/fhir-packages" > /tmp/fhir-cache-list.txt
+              kubectl -n fume exec "$POD" -- sh -c "ls -1 /usr/fume/fhir-packages" > /tmp/fhir-cache-list.txt
               exit 0;
             fi
             [ $i -eq 20 ] && echo "::error::Did not find $TARGET_DIR in fhir-cache" && exit 1
@@ -217,10 +219,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/diagnostics
-          kubectl -n fume describe statefulset fume-backend > /tmp/diagnostics/statefulset.txt || true
-          kubectl -n fume describe pod fume-backend-0 > /tmp/diagnostics/pod.txt || true
-          kubectl -n fume logs statefulset/fume-backend --tail=400 > /tmp/diagnostics/pod-logs.txt || true
-          kubectl -n fume exec fume-backend-0 -- sh -c 'for f in /usr/fume/logs/*.log; do echo "==== $f (tail 200) ===="; tail -n 200 "$f"; done' > /tmp/diagnostics/app-logs.txt || true
+          POD=$(kubectl -n fume get pods -l app.kubernetes.io/component=backend -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo '')
+          kubectl -n fume describe deployment fume-backend > /tmp/diagnostics/deployment.txt || true
+          if [ -n "$POD" ]; then
+            kubectl -n fume describe pod "$POD" > /tmp/diagnostics/pod.txt || true
+            kubectl -n fume exec "$POD" -- sh -c 'for f in /usr/fume/logs/*.log; do echo "==== $f (tail 200) ===="; tail -n 200 "$f"; done' > /tmp/diagnostics/app-logs.txt || true
+          fi
+          kubectl -n fume logs deployment/fume-backend --tail=400 > /tmp/diagnostics/pod-logs.txt || true
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,93 @@
+# FUME Enterprise environment variables (self-contained)
+
+This document lists the supported environment variables for FUME Enterprise deployments.
+
+It is intentionally self-contained so it can be shipped to customers without requiring access to any private repositories.
+
+## Conventions
+
+- **Runtime required?** means the config schema rejects startup when missing.
+  - Many variables are still *operationally required* for production even if they have defaults.
+- **Recommended K8s source** is how we suggest injecting the variable when using Helm.
+- **Secret?** indicates whether the value should normally be stored in a Kubernetes Secret.
+
+Additional operator notes:
+
+- Several settings support the sentinel value `n/a` to mean “disabled” (notably `FHIR_SERVER_BASE`, `FHIR_PACKAGE_REGISTRY_URL`, and `MAPPINGS_FOLDER`).
+- Empty/whitespace values should be treated as “unset”.
+- When both `FHIR_SERVER_BASE` and `MAPPINGS_FOLDER` are unset/`n/a`, the `/Mapping/*` endpoints are disabled (return `405`), but ad-hoc `POST /` evaluation remains available.
+
+## Backend (FUME Engine / Server)
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `SERVER_PORT` | No | `42420` | values.env | No | Port the backend listens on. Typically matches Service targetPort. |
+| `FUME_REQUEST_BODY_LIMIT` | No | `400mb` | values.env | No | Max request body size accepted by the HTTP server (json/xml/csv/hl7v2). Examples: `10mb`, `100kb`, `1gb`. |
+| `LOG_LEVEL` | No | `info` | values.env | No | Global logging verbosity. Accepts `debug`/`info`/`warn`/`error`/`silent` (`silent` also accepts aliases like `off`). |
+
+### Evaluation policy thresholds (fumifier)
+
+Numeric severities (lower = more critical): fatal=0, invalid=10, error=20, warning=30, notice=40, info=50, debug=60.
+Threshold comparisons are exclusive: an action triggers when `severity < threshold`.
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `FUME_EVAL_THROW_LEVEL` | No | `30` | values.env | No | When severity is below this, evaluation throws. |
+| `FUME_EVAL_LOG_LEVEL` | No | `40` | values.env | No | Controls per-evaluation policy logging threshold. |
+| `FUME_EVAL_DIAG_COLLECT_LEVEL` | No | `70` | values.env | No | Diagnostic collection threshold. |
+| `FUME_EVAL_VALIDATION_LEVEL` | No | `30` | values.env | No | Validation threshold. |
+
+### FHIR server connection
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `FHIR_SERVER_BASE` | No | `""` | secrets.fume | Usually | FHIR server base URL. Set to `n/a` to disable server source. |
+| `FHIR_SERVER_AUTH_TYPE` | No | `NONE` | values.env | No | `NONE` or `BASIC`. |
+| `FHIR_SERVER_UN` | No | `""` | secrets.fume | Yes | BASIC username. |
+| `FHIR_SERVER_PW` | No | `""` | secrets.fume | Yes | BASIC password. |
+| `FHIR_SERVER_TIMEOUT` | No | `30000` | values.env | No | Timeout in ms for FHIR server calls. |
+
+### FHIR packages and registries
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `FHIR_VERSION` | No | `4.0.1` | values.env | No | Default FHIR version. |
+| `FHIR_PACKAGES` | No | `""` | values.configMap | No | Comma-separated list of `pkg@version`. Operationally required for most deployments. |
+| `FHIR_PACKAGE_REGISTRY_URL` | No | (none) | values.configMap | No | Optional. Supports `n/a`. |
+| `FHIR_PACKAGE_REGISTRY_TOKEN` | No | (none) | secrets.fume | Yes | Optional auth token for private registry (base64-encoded, no `Bearer`). |
+| `FHIR_PACKAGE_CACHE_DIR` | No | (none) | chart-managed | No | In Helm, prefer the fixed mount `/usr/fume/fhir-packages`. If overriding, mounts must follow. |
+
+### Mappings file store (optional)
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `MAPPINGS_FOLDER` | No | (none) | chart-managed when enabled | No | Set to a folder path to enable file-backed mappings + aliases. Set to `n/a` (or unset) to disable. |
+| `MAPPINGS_FILE_EXTENSION` | No | (none) | values.env | No | Default is applied by provider; commonly `.fume`. |
+| `MAPPINGS_FILE_POLLING_INTERVAL_MS` | No | (none) | values.env | No | Optional. Set <= 0 to disable interval (provider behavior). |
+| `MAPPINGS_SERVER_POLLING_INTERVAL_MS` | No | (none) | values.env | No | Optional. |
+| `MAPPINGS_FORCED_RESYNC_INTERVAL_MS` | No | (none) | values.env | No | Optional. |
+| `MAPPINGS_PRIMARY_WRITABLE_STORE` | No | (none) | values.env | No | `file` / `server` / `none`. If `file`, `MAPPINGS_FOLDER` must be configured. |
+
+### Cache warmup / performance
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `PREBUILD_SNAPSHOTS` | No | `true` | values.env | No | Warm snapshot + terminology caches in background. Caches are stored under the package cache volume (`FHIR_PACKAGE_CACHE_DIR`). |
+| `FUME_COMPILED_EXPR_CACHE_MAX_ENTRIES` | No | `1000` | values.env | No | In-process cache size. Not shareable between pods. |
+| `FUME_AST_CACHE_MAX_ENTRIES` | No | `1000` | values.env | No | In-process cache size. Not shareable between pods. |
+
+### Canonical + license
+
+| Variable | Runtime required? | Default (if any) | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---|---:|---|
+| `CANONICAL_BASE_URL` | No | `http://example.fume.health` | values.configMap | No | Base URL used for generated canonicals. Many deployments treat this as required. |
+| `FUME_LICENSE` | No | `""` | (not recommended) | No | Prefer mounting license file(s) from a Secret. License files are safe to share across pods. |
+
+## Frontend (FUME Designer) — when deployed
+
+These values are consumed by the Designer / browser.
+
+| Variable | Required (if frontend enabled)? | Recommended K8s source | Secret? | Notes |
+|---|---:|---|---:|---|
+| `FUME_SERVER_URL` | Yes | values.configMap | No | URL that the user's browser uses to call the backend API. Must be reachable from the user's network.
+| `FUME_DESIGNER_HEADLINE` | No | values.env | No | Cosmetic headline / environment marker.

--- a/MIGRATING_TO_FUME_MAJOR.md
+++ b/MIGRATING_TO_FUME_MAJOR.md
@@ -1,0 +1,200 @@
+# Migrating to the new major FUME Enterprise Helm deployment
+
+This guide is for platform/DevOps teams upgrading from the previous enterprise Helm deployment to the new major FUME release after the toolchain refactor.
+
+## What changed (high level)
+
+- **Configuration surface changed**: environment variables were added/removed/renamed.
+  - See `ENVIRONMENT_VARIABLES.md` in this repo for the supported variables.
+- **Backend workload type is changing**: the enterprise backend is moving from a **StatefulSet** model to a **Deployment** model.
+- **Shared caches are now supported and recommended**:
+  - FHIR package cache
+  - Templates cache
+  - New optional mappings folder (file-backed mappings store)
+  - Snapshot/terminology caches now live under the FHIR package cache volume (no separate snapshots volume)
+
+## Pre-migration checklist
+
+1) Identify your currently deployed release
+
+```bash
+helm list -n <namespace>
+helm get values <release> -n <namespace>
+```
+
+2) Inventory your current storage
+
+```bash
+kubectl get pvc -n <namespace>
+kubectl get statefulset,deploy -n <namespace>
+```
+
+If you are currently using the chart’s per-pod PVCs (StatefulSet `volumeClaimTemplates`), you will likely see PVCs with names like:
+
+- `<release>-fume-backend-templates-0`
+- `<release>-fume-backend-fhir-cache-0`
+
+Note: older deployments may also have had a snapshots PVC/mount. In the new major, snapshots are cached under the package cache volume, so there is no dedicated snapshots PVC.
+
+3) Confirm your cluster supports RWX if you plan to run multiple backend replicas
+
+To share a single PVC between multiple pods, your storage backend must support `ReadWriteMany` (RWX) (examples: NFS, EFS, AzureFile).
+
+If you only have `ReadWriteOnce` (RWO), pick one:
+
+- run a single backend replica, or
+- keep the StatefulSet pattern, or
+- accept per-pod caches using `emptyDir`.
+
+## Configuration migration (env vars)
+
+### Source of truth
+
+Use `ENVIRONMENT_VARIABLES.md` in this repo as the authoritative list of supported environment variables.
+
+### How env vars are provided in Helm
+
+Most enterprise installations should split variables into:
+
+- **ConfigMap values** (non-secret but important): e.g. `CANONICAL_BASE_URL`, `FHIR_PACKAGES`, `FHIR_PACKAGE_REGISTRY_URL`
+- **Secret values** (sensitive): e.g. `FHIR_SERVER_BASE`, `FHIR_SERVER_UN`, `FHIR_SERVER_PW`, `FHIR_PACKAGE_REGISTRY_TOKEN`
+- **Plain env values**: e.g. `LOG_LEVEL`, `FHIR_SERVER_TIMEOUT`, `PREBUILD_SNAPSHOTS`, `MAPPINGS_*` settings
+
+### Common new/updated settings (examples)
+
+- Request limits and logging:
+  - `FUME_REQUEST_BODY_LIMIT`
+  - `LOG_LEVEL`
+- Evaluation policy thresholds:
+  - `FUME_EVAL_THROW_LEVEL`
+  - `FUME_EVAL_LOG_LEVEL`
+  - `FUME_EVAL_DIAG_COLLECT_LEVEL`
+  - `FUME_EVAL_VALIDATION_LEVEL`
+- Cache warmup:
+  - `PREBUILD_SNAPSHOTS` (enterprise default is usually `true`)
+- Mapping provider file store (optional):
+  - `MAPPINGS_FOLDER`
+  - `MAPPINGS_PRIMARY_WRITABLE_STORE` (`file` / `server` / `none`)
+
+## Storage migration
+
+### Goal
+
+Move from per-pod PVCs (StatefulSet) to shared PVCs (Deployment) for the following safe-to-share folders:
+
+- `/usr/fume/fhir-packages` (FHIR package cache)
+- `/usr/fume/templates` (templates cache)
+- `/usr/fume/mappings` (optional; file-backed mappings)
+
+Snapshot + terminology caches are stored under the package cache folder (`/usr/fume/fhir-packages`).
+
+### Strategy options
+
+#### Option A — Parallel install + cutover (recommended)
+
+1) Install the new chart under a new release name (same namespace or a new namespace).
+2) Validate health checks, API behavior, and (if applicable) designer connectivity.
+3) Switch traffic (Ingress host/path, or Service selector changes depending on your setup).
+4) Decommission old release.
+
+Pros: lowest risk, easiest rollback.
+
+#### Option B — In-place upgrade with data copy
+
+This option is more manual but keeps the same release name.
+
+1) Scale down old backend
+
+```bash
+kubectl scale statefulset/<old-backend> -n <namespace> --replicas=0
+```
+
+2) Create the new shared PVCs (RWX)
+
+Create PVCs for the new Deployment-based chart (names depend on the updated chart). Examples:
+
+- `<release>-fhir-cache`
+- `<release>-templates`
+- `<release>-mappings` (optional)
+
+3) Copy data from old per-pod PVCs into the new shared PVCs
+
+The most reliable pattern is a temporary helper pod per PVC.
+
+Example helper pod (edit `claimName` and mountPath per volume):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-migrator
+  namespace: <namespace>
+spec:
+  containers:
+    - name: shell
+      image: alpine:3.20
+      command: ["/bin/sh","-c","sleep 36000"]
+      volumeMounts:
+        - name: old
+          mountPath: /old
+        - name: new
+          mountPath: /new
+  volumes:
+    - name: old
+      persistentVolumeClaim:
+        claimName: <old-pvc-name>
+    - name: new
+      persistentVolumeClaim:
+        claimName: <new-pvc-name>
+```
+
+Then inside the pod:
+
+```bash
+kubectl exec -it pvc-migrator -n <namespace> -- sh
+
+# Example copy (preserve timestamps/permissions where possible)
+cp -a /old/. /new/
+```
+
+4) Upgrade the Helm release
+
+Depending on how the chart is updated (StatefulSet → Deployment), you may need to delete the old StatefulSet object before Helm can create the Deployment.
+
+## StatefulSet → Deployment caveats
+
+- Helm cannot always “mutate” a StatefulSet into a Deployment cleanly.
+- Expect at least one disruptive operation (delete/create) for the backend workload.
+- Plan a maintenance window.
+
+## Post-migration verification
+
+1) Verify pods
+
+```bash
+kubectl get pods -n <namespace>
+kubectl logs -n <namespace> deploy/<backend-deploy> --tail=200
+```
+
+2) Verify env
+
+```bash
+kubectl exec -n <namespace> deploy/<backend-deploy> -- printenv | sort
+```
+
+3) Verify mounted caches
+
+```bash
+kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/fhir-packages | head
+kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/templates | head
+kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/mappings | head  # if enabled
+
+## License note
+
+License files are safe to share between pods. Prefer mounting the license from a Kubernetes Secret to each pod (no per-pod state required).
+```
+
+## Rollback
+
+- If you used the parallel install approach, rollback is typically just switching traffic back.
+- If you upgraded in-place, rollback may require restoring the previous manifests and re-attaching old PVCs.

--- a/MIGRATING_TO_FUME_MAJOR.md
+++ b/MIGRATING_TO_FUME_MAJOR.md
@@ -189,10 +189,11 @@ kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/fhir-pac
 kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/templates | head
 kubectl exec -n <namespace> deploy/<backend-deploy> -- ls -la /usr/fume/mappings | head  # if enabled
 
+```
+
 ## License note
 
 License files are safe to share between pods. Prefer mounting the license from a Kubernetes Secret to each pod (no per-pod state required).
-```
 
 ## Rollback
 

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 0.4.2
-appVersion: "1.8.1"
+version: 1.0.0
+appVersion: "3.0.0"
 maintainers:
   - name: Outburn Ltd.
 keywords:

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -85,10 +85,10 @@ Update the image settings in `values.yaml` (or override in `values.prod.yaml`) o
 image:
   backend:
     repository: outburnltd/fume-enterprise-server  # Private Docker Hub repository
-    tag: "1.8.0"
+    tag: "3.0.0"
   frontend:
     repository: outburnltd/fume-designer           # Private Docker Hub repository  
-    tag: "2.1.3"
+    tag: "3.0.0"
   pullPolicy: IfNotPresent
   pullSecret: "dockerhub-secret"  # Optional: set if your cluster/namespace doesn't already provide pull credentials
 ```

--- a/helm/fume/templates/NOTES.txt
+++ b/helm/fume/templates/NOTES.txt
@@ -30,11 +30,16 @@
    {{- end }}
 
 3. Storage:
-   {{- if .Values.storage.snapshots.enabled }}
-   - Snapshots PVC: {{ include "fume.fullname" . }}-snapshots ({{ .Values.storage.snapshots.size }})
-   {{- end }}
    {{- if .Values.storage.templates.enabled }}
-   - Templates PVC: {{ include "fume.fullname" . }}-templates ({{ .Values.storage.templates.size }})
+   - Templates PVC: {{ .Values.storage.templates.existingClaim | default (printf "%s-templates" (include "fume.fullname" .)) }} ({{ .Values.storage.templates.size }})
+   {{- end }}
+   {{- if .Values.storage.fhirCache.enabled }}
+   - FHIR cache PVC: {{ .Values.storage.fhirCache.existingClaim | default (printf "%s-fhir-cache" (include "fume.fullname" .)) }} ({{ .Values.storage.fhirCache.size }})
+   {{- else }}
+   - FHIR cache: emptyDir (ephemeral)
+   {{- end }}
+   {{- if .Values.storage.mappings.enabled }}
+   - Mappings PVC: {{ .Values.storage.mappings.existingClaim | default (printf "%s-mappings" (include "fume.fullname" .)) }} ({{ .Values.storage.mappings.size }})
    {{- end }}
    - Logs: EmptyDir volumes
 

--- a/helm/fume/templates/_helpers.tpl
+++ b/helm/fume/templates/_helpers.tpl
@@ -73,8 +73,10 @@ Validate required configuration values
 {{- if or (not (hasKey $cfg "CANONICAL_BASE_URL")) (eq (index $cfg "CANONICAL_BASE_URL") "") }}
 	{{- fail "CANONICAL_BASE_URL is required. Set via --set configMap.CANONICAL_BASE_URL=\"https://fume.your-company.com\"" }}
 {{- end }}
+{{- if .Values.enableFrontend }}
 {{- if or (not (hasKey $cfg "FUME_SERVER_URL")) (eq (index $cfg "FUME_SERVER_URL") "") }}
-	{{- fail "FUME_SERVER_URL is required. Set via --set configMap.FUME_SERVER_URL=\"https://your-fume-api.com\"" }}
+	{{- fail "FUME_SERVER_URL is required when enableFrontend=true. Set via --set configMap.FUME_SERVER_URL=\"https://your-fume-api.com\"" }}
+{{- end }}
 {{- end }}
 {{- if or (not (hasKey $cfg "FHIR_PACKAGES")) (eq (index $cfg "FHIR_PACKAGES") "") }}
 	{{- fail "FHIR_PACKAGES is required (jurisdiction/context specific). Example: --set configMap.FHIR_PACKAGES=\"pkg1@x.y.z,pkg2,pkg3@a.b.c\"" }}

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -1,12 +1,11 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "fume.fullname" . }}-backend
   labels:
     {{- include "fume.labels" . | nindent 4 }}
     app.kubernetes.io/component: backend
 spec:
-  serviceName: {{ include "fume.fullname" . }}-backend-headless
   {{- if not .Values.autoscaling.backend.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
   {{- end }}
@@ -63,6 +62,11 @@ spec:
             # Deterministic cache directory (persistent or ephemeral depending on storage.fhirCache.enabled)
             - name: FHIR_PACKAGE_CACHE_DIR
               value: "/usr/fume/fhir-packages"
+            {{- $env := .Values.env | default dict }}
+            {{- if and .Values.storage.mappings.enabled (not (hasKey $env "MAPPINGS_FOLDER")) }}
+            - name: MAPPINGS_FOLDER
+              value: "/usr/fume/mappings"
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             {{- if $value }}
             - name: {{ $key }}
@@ -87,13 +91,19 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: /usr/fume/logs
-            - name: snapshots
-              mountPath: /usr/fume/snapshots
             - name: templates
               mountPath: /usr/fume/templates
             # Writable cache directory for FHIR packages (non-root friendly fixed path)
             - name: fhir-cache
               mountPath: /usr/fume/fhir-packages
+            {{- /* Mount /usr/fume/mappings when chart storage is enabled OR when user explicitly sets MAPPINGS_FOLDER to the default path */ -}}
+            {{- $mappingsFolder := "/usr/fume/mappings" }}
+            {{- $hasMappingsEnv := hasKey $env "MAPPINGS_FOLDER" }}
+            {{- $useMappingsMount := or .Values.storage.mappings.enabled (and $hasMappingsEnv (eq (index $env "MAPPINGS_FOLDER") $mappingsFolder)) }}
+            {{- if $useMappingsMount }}
+            - name: mappings
+              mountPath: /usr/fume/mappings
+            {{- end }}
             # Mount license as a single file
             - name: license
               mountPath: /usr/fume/license.key.lic
@@ -111,26 +121,33 @@ spec:
       volumes:
         - name: logs
           emptyDir: {}
-        # When snapshots/templates persistence enabled their PVCs come from volumeClaimTemplates.
-        # Provide emptyDir only when disabled so mounts still exist.
-        {{- if not .Values.storage.snapshots.enabled }}
-        - name: snapshots
-          emptyDir: {}
-        {{- end }}
-        {{- if not .Values.storage.templates.enabled }}
+        # templates: shared PVC (recommended) or emptyDir
+        {{- if .Values.storage.templates.enabled }}
+        - name: templates
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.templates.existingClaim | default (printf "%s-templates" (include "fume.fullname" .)) }}
+        {{- else }}
         - name: templates
           emptyDir: {}
         {{- end }}
-        # fhir-cache: persistent via claim template when enabled & no existingClaim; emptyDir otherwise or when existingClaim specified we mount that claim explicitly.
+        # fhir-cache: shared PVC or emptyDir
         {{- if .Values.storage.fhirCache.enabled }}
-        {{- if .Values.storage.fhirCache.existingClaim }}
         - name: fhir-cache
           persistentVolumeClaim:
-            claimName: {{ .Values.storage.fhirCache.existingClaim }}
-        {{- end }}
+            claimName: {{ .Values.storage.fhirCache.existingClaim | default (printf "%s-fhir-cache" (include "fume.fullname" .)) }}
         {{- else }}
         - name: fhir-cache
           emptyDir: {}
+        {{- end }}
+        # mappings: optional; only mounted when enabled or when env explicitly sets MAPPINGS_FOLDER=/usr/fume/mappings
+        {{- if $useMappingsMount }}
+        - name: mappings
+          {{- if .Values.storage.mappings.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.mappings.existingClaim | default (printf "%s-mappings" (include "fume.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
         - name: license
           secret:
@@ -167,28 +184,3 @@ spec:
           volumeMounts:
             - name: fhir-index
               mountPath: /index
-  {{- $claimTemplates := list }}
-  {{- if .Values.storage.snapshots.enabled }}
-  {{- $claimTemplates = append $claimTemplates (dict "name" "snapshots" "accessMode" .Values.storage.snapshots.accessMode "storageClass" .Values.storage.snapshots.storageClass "size" .Values.storage.snapshots.size) }}
-  {{- end }}
-  {{- if .Values.storage.templates.enabled }}
-  {{- $claimTemplates = append $claimTemplates (dict "name" "templates" "accessMode" .Values.storage.templates.accessMode "storageClass" .Values.storage.templates.storageClass "size" .Values.storage.templates.size) }}
-  {{- end }}
-  {{- if and .Values.storage.fhirCache.enabled (not .Values.storage.fhirCache.existingClaim) }}
-  {{- $claimTemplates = append $claimTemplates (dict "name" "fhir-cache" "accessMode" .Values.storage.fhirCache.accessMode "storageClass" .Values.storage.fhirCache.storageClass "size" .Values.storage.fhirCache.size) }}
-  {{- end }}
-  {{- if gt (len $claimTemplates) 0 }}
-  volumeClaimTemplates:
-  {{- range $ct := $claimTemplates }}
-    - metadata:
-        name: {{ $ct.name }}
-        labels:
-          {{- include "fume.labels" $ | nindent 10 }}
-      spec:
-        accessModes: [ "{{ $ct.accessMode }}" ]
-        storageClassName: {{ $ct.storageClass | quote }}
-        resources:
-          requests:
-            storage: {{ $ct.size }}
-  {{- end }}
-  {{- end }}

--- a/helm/fume/templates/backend-headless-service.yaml
+++ b/helm/fume/templates/backend-headless-service.yaml
@@ -1,4 +1,6 @@
-# this will generate hostnames like fume-backend-0.fume-backend-headless.fume.svc.cluster.local
+{{- if .Values.backend.headlessService.enabled }}
+# This will generate hostnames like fume-backend-0.fume-backend-headless.fume.svc.cluster.local
+# It is primarily useful for StatefulSet stable identities.
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +17,4 @@ spec:
   selector:
     {{- include "fume.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: backend
+{{- end }}

--- a/helm/fume/templates/hpa.yaml
+++ b/helm/fume/templates/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: StatefulSet
+    kind: Deployment
     name: {{ include "fume.fullname" . }}-backend
   minReplicas: {{ .Values.autoscaling.backend.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.backend.maxReplicas }}

--- a/helm/fume/templates/pvc.yaml
+++ b/helm/fume/templates/pvc.yaml
@@ -2,51 +2,51 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-	name: {{ include "fume.fullname" . }}-templates
-	labels:
-		{{- include "fume.labels" . | nindent 4 }}
+  name: {{ include "fume.fullname" . }}-templates
+  labels:
+    {{- include "fume.labels" . | nindent 4 }}
 spec:
-	accessModes: [ "{{ .Values.storage.templates.accessMode }}" ]
-	{{- if .Values.storage.templates.storageClass }}
-	storageClassName: {{ .Values.storage.templates.storageClass | quote }}
-	{{- end }}
-	resources:
-		requests:
-			storage: {{ .Values.storage.templates.size }}
----
+  accessModes: [ "{{ .Values.storage.templates.accessMode }}" ]
+  {{- if .Values.storage.templates.storageClass }}
+  storageClassName: {{ .Values.storage.templates.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.templates.size }}
 {{- end }}
 
 {{- if and .Values.storage.fhirCache.enabled (not .Values.storage.fhirCache.existingClaim) }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-	name: {{ include "fume.fullname" . }}-fhir-cache
-	labels:
-		{{- include "fume.labels" . | nindent 4 }}
+  name: {{ include "fume.fullname" . }}-fhir-cache
+  labels:
+    {{- include "fume.labels" . | nindent 4 }}
 spec:
-	accessModes: [ "{{ .Values.storage.fhirCache.accessMode }}" ]
-	{{- if .Values.storage.fhirCache.storageClass }}
-	storageClassName: {{ .Values.storage.fhirCache.storageClass | quote }}
-	{{- end }}
-	resources:
-		requests:
-			storage: {{ .Values.storage.fhirCache.size }}
----
+  accessModes: [ "{{ .Values.storage.fhirCache.accessMode }}" ]
+  {{- if .Values.storage.fhirCache.storageClass }}
+  storageClassName: {{ .Values.storage.fhirCache.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.fhirCache.size }}
 {{- end }}
 
 {{- if and .Values.storage.mappings.enabled (not .Values.storage.mappings.existingClaim) }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-	name: {{ include "fume.fullname" . }}-mappings
-	labels:
-		{{- include "fume.labels" . | nindent 4 }}
+  name: {{ include "fume.fullname" . }}-mappings
+  labels:
+    {{- include "fume.labels" . | nindent 4 }}
 spec:
-	accessModes: [ "{{ .Values.storage.mappings.accessMode }}" ]
-	{{- if .Values.storage.mappings.storageClass }}
-	storageClassName: {{ .Values.storage.mappings.storageClass | quote }}
-	{{- end }}
-	resources:
-		requests:
-			storage: {{ .Values.storage.mappings.size }}
+  accessModes: [ "{{ .Values.storage.mappings.accessMode }}" ]
+  {{- if .Values.storage.mappings.storageClass }}
+  storageClassName: {{ .Values.storage.mappings.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.mappings.size }}
 {{- end }}

--- a/helm/fume/templates/pvc.yaml
+++ b/helm/fume/templates/pvc.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.storage.templates.enabled (not .Values.storage.templates.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+	name: {{ include "fume.fullname" . }}-templates
+	labels:
+		{{- include "fume.labels" . | nindent 4 }}
+spec:
+	accessModes: [ "{{ .Values.storage.templates.accessMode }}" ]
+	{{- if .Values.storage.templates.storageClass }}
+	storageClassName: {{ .Values.storage.templates.storageClass | quote }}
+	{{- end }}
+	resources:
+		requests:
+			storage: {{ .Values.storage.templates.size }}
+---
+{{- end }}
+
+{{- if and .Values.storage.fhirCache.enabled (not .Values.storage.fhirCache.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+	name: {{ include "fume.fullname" . }}-fhir-cache
+	labels:
+		{{- include "fume.labels" . | nindent 4 }}
+spec:
+	accessModes: [ "{{ .Values.storage.fhirCache.accessMode }}" ]
+	{{- if .Values.storage.fhirCache.storageClass }}
+	storageClassName: {{ .Values.storage.fhirCache.storageClass | quote }}
+	{{- end }}
+	resources:
+		requests:
+			storage: {{ .Values.storage.fhirCache.size }}
+---
+{{- end }}
+
+{{- if and .Values.storage.mappings.enabled (not .Values.storage.mappings.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+	name: {{ include "fume.fullname" . }}-mappings
+	labels:
+		{{- include "fume.labels" . | nindent 4 }}
+spec:
+	accessModes: [ "{{ .Values.storage.mappings.accessMode }}" ]
+	{{- if .Values.storage.mappings.storageClass }}
+	storageClassName: {{ .Values.storage.mappings.storageClass | quote }}
+	{{- end }}
+	resources:
+		requests:
+			storage: {{ .Values.storage.mappings.size }}
+{{- end }}

--- a/helm/fume/values.prod.yaml
+++ b/helm/fume/values.prod.yaml
@@ -25,11 +25,18 @@ backend:
 
 # Storage configuration for production
 storage:
-  snapshots:
-    size: 100Gi
-    storageClass: "ssd"
   templates:
+    enabled: true
+    # For multi-replica backends, templates storage must be RWX-capable (or run replicaCount=1).
+    accessMode: ReadWriteMany
     size: 5Gi
+    storageClass: "ssd"
+
+  # Recommended for production: persistent shared package cache (also holds snapshot/terminology caches in v3)
+  fhirCache:
+    enabled: true
+    accessMode: ReadWriteMany
+    size: 100Gi
     storageClass: "ssd"
 
 # Environment variables for production

--- a/helm/fume/values.schema.json
+++ b/helm/fume/values.schema.json
@@ -77,29 +77,14 @@
     "storage": {
       "type": "object",
       "properties": {
-        "snapshots": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            },
-            "size": {
-              "type": "string"
-            },
-            "storageClass": {
-              "type": "string"
-            },
-            "accessMode": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
         "templates": {
           "type": "object",
           "properties": {
             "enabled": {
               "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
             },
             "size": {
               "type": "string"
@@ -114,6 +99,27 @@
           "additionalProperties": false
         },
         "fhirCache": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingClaim": {
+              "type": "string"
+            },
+            "size": {
+              "type": "string"
+            },
+            "storageClass": {
+              "type": "string"
+            },
+            "accessMode": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "mappings": {
           "type": "object",
           "properties": {
             "enabled": {
@@ -152,13 +158,36 @@
     "env": {
       "type": "object",
       "properties": {
-        "SERVER_STATELESS": {
-          "type": [
-            "string",
-            "boolean"
+        "SERVER_PORT": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "FUME_REQUEST_BODY_LIMIT": {
+          "type": "string"
+        },
+        "LOG_LEVEL": {
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "silent"
           ]
         },
-        "SERVER_PORT": {
+        "FUME_EVAL_THROW_LEVEL": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "FUME_EVAL_LOG_LEVEL": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "FUME_EVAL_DIAG_COLLECT_LEVEL": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "FUME_EVAL_VALIDATION_LEVEL": {
           "type": "string",
           "pattern": "^[0-9]+$"
         },
@@ -171,6 +200,39 @@
           "enum": [
             "NONE",
             "BASIC"
+          ]
+        },
+        "FHIR_SERVER_TIMEOUT": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "MAPPINGS_FILE_EXTENSION": {
+          "type": "string"
+        },
+        "MAPPINGS_FILE_POLLING_INTERVAL_MS": {
+          "type": "string",
+          "pattern": "^-?[0-9]+$"
+        },
+        "MAPPINGS_SERVER_POLLING_INTERVAL_MS": {
+          "type": "string",
+          "pattern": "^-?[0-9]+$"
+        },
+        "MAPPINGS_FORCED_RESYNC_INTERVAL_MS": {
+          "type": "string",
+          "pattern": "^-?[0-9]+$"
+        },
+        "MAPPINGS_PRIMARY_WRITABLE_STORE": {
+          "type": "string",
+          "enum": [
+            "file",
+            "server",
+            "none"
+          ]
+        },
+        "PREBUILD_SNAPSHOTS": {
+          "type": [
+            "string",
+            "boolean"
           ]
         },
         "FUME_DESIGNER_HEADLINE": {

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -36,6 +36,12 @@ backend:
   tolerations: []
   affinity: {}
 
+  # Optional: create a backend headless Service (clusterIP: None).
+  # This is primarily useful for StatefulSet stable identities and is usually unnecessary
+  # with the backend Deployment model.
+  headlessService:
+    enabled: false
+
 # Frontend configuration (when enabled)
 frontend:
   replicaCount: 1
@@ -86,13 +92,10 @@ ingress:
 
 # Storage configuration
 storage:
-  snapshots:
-    enabled: true
-    size: 5Gi
-    storageClass: ""
-    accessMode: ReadWriteOnce
   templates:
     enabled: true
+    # Either reference an existing claim by name, or let the chart create one (when enabled and existingClaim is empty)
+    existingClaim: ""
     size: 1Gi
     storageClass: ""
     accessMode: ReadWriteOnce
@@ -107,6 +110,16 @@ storage:
     size: 5Gi
     storageClass: ""
     accessMode: ReadWriteOnce
+
+  # Optional persistent mappings folder for file-backed mappings.
+  # When enabled, the backend mounts a PVC at /usr/fume/mappings and the chart sets
+  # MAPPINGS_FOLDER=/usr/fume/mappings unless you override it explicitly in env.
+  mappings:
+    enabled: false
+    existingClaim: ""
+    size: 1Gi
+    storageClass: ""
+    accessMode: ReadWriteMany
 
   # No extra configuration needed for the index file; it's handled via emptyDir.
 
@@ -165,14 +178,14 @@ probes:
   backend:
     liveness:
       enabled: true
-      path: /
+      path: /health
       initialDelaySeconds: 120  # 2 minutes for warm start, will be faster on restart
       periodSeconds: 30
       timeoutSeconds: 10
       failureThreshold: 10      # Allow for slow startup (10 * 30s = 5min tolerance)
     readiness:
       enabled: true
-      path: /
+      path: /health
       initialDelaySeconds: 60   # 1 minute initial delay
       periodSeconds: 10
       timeoutSeconds: 5

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,10 +13,10 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "1.8.1"  # Backend application version (matches Chart appVersion unless overridden)
+    tag: "3.0.0"
   frontend:
     repository: outburnltd/fume-designer
-    tag: "2.1.3"
+    tag: "3.0.0"
   pullPolicy: IfNotPresent
   pullSecret: ""  # Optional: set to a Secret name only if namespace/service account doesn't already provide pull access
 


### PR DESCRIPTION
- Updated Chart.yaml to version 1.0.0 and appVersion to 3.0.0.
- Modified helm-e2e.yml to create application secrets with simplified FHIR server values.
- Changed backend deployment from StatefulSet to Deployment in backend-deployment.yaml.
- Updated HPA configuration to target Deployment instead of StatefulSet.
- Enhanced README.md to reflect changes in storage configuration and health probe paths.
- Added new mappings storage configuration and updated values.prod.yaml accordingly.
- Introduced ENVIRONMENT_VARIABLES.md for comprehensive environment variable documentation.
- Created MIGRATING_TO_FUME_MAJOR.md to guide users through the migration process to the new major release.
- Updated values.schema.json to include new mappings and fhirCache configurations.
- Adjusted PVC templates to support new shared storage model for templates and fhirCache.
- Improved NOTES.txt to clarify storage configurations and PVC details.