### PR TITLE
feat: add support for named FHIR connections and auth configuration in Helm chart

### DIFF
--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -3,7 +3,7 @@ name: fume
 description: A Helm chart for FUME Enterprise
 type: application
 version: 1.1.0
-appVersion: "3.0.3"
+appVersion: "3.1.0"
 maintainers:
   - name: Outburn Ltd.
 keywords:

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 1.0.0
-appVersion: "3.0.0"
+version: 1.1.0
+appVersion: "3.0.3"
 maintainers:
   - name: Outburn Ltd.
 keywords:

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -11,6 +11,7 @@ This Helm chart deploys the FUME application stack on Kubernetes, including:
 - [Configuration](#configuration)
 - [Secrets and License Setup](#secrets-and-license-setup)
 - [Named FHIR Connections](#named-fhir-connections)
+- [Auth Configuration](#auth-configuration)
 - [Storage Configuration](#storage-configuration)
 - [Environment-Specific Deployments](#environment-specific-deployments)
 - [Upgrading](#upgrading)
@@ -300,6 +301,75 @@ Notes:
 - You can keep sensitive values out of the authored YAML by using `${ENV_VAR}` placeholders and supplying those variables through your existing Secret management flow.
 - `env.FHIR_CONNECTIONS_URL_POOL_SIZE` remains the way to tune named-connection URL pooling.
 - If `fhirConnections.enabled=true`, do not set `env.FHIR_CONNECTIONS_FILE` to a different path; the chart will fail fast on that conflict.
+
+## Auth Configuration
+
+The chart can render a Secret-backed `auth.yaml` and mount it into the backend automatically. When enabled, it also sets `AUTH_CONFIG_PATH` to the mounted file path on the backend, and turns on the designer's auth mode by setting `FUME_DESIGNER_AUTH_ENABLED=true` (unless you explicitly set it under `env`).
+
+See the auth schema reference in the FUME backend repo (`src/auth/README.md`) for the full set of options. Use a values file for the YAML payload — multiline policy content is awkward via `--set`.
+
+Example values file (PKCE mode):
+
+```yaml
+auth:
+  enabled: true
+  mountPath: /usr/fume/auth.yaml
+  yaml: |
+    version: 1
+    keycloak:
+      issuer: https://kc.example.com/realms/fume
+    designerClient:
+      clientId: fume
+    resource:
+      url: https://api.example.com
+      name: FUME
+    policy:
+      defaultRule: { access: authenticated }
+      routes:
+        - path: /
+          methods:
+            GET: { access: public }
+```
+
+Example values file (token-mediator / BFF mode, with secret interpolation):
+
+```yaml
+auth:
+  enabled: true
+  yaml: |
+    version: 1
+    keycloak:
+      issuer: https://kc.example.com/realms/fume
+      client:
+        id: fume
+        secret: ${KC_CLIENT_SECRET}
+    tokenMediator:
+      enabled: true
+      corsAllowedOrigins:
+        - https://designer.example.com
+    resource:
+      url: https://api.example.com
+      name: FUME
+    policy:
+      defaultRule: { access: authenticated }
+```
+
+Deploy with the extra values file:
+
+```bash
+helm install fume ./helm/fume \
+  --namespace fume \
+  -f ./helm/fume/values.auth.yaml \
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
+  --set configMap.FUME_SERVER_URL="https://your-fume-api.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
+```
+
+Notes:
+- The `auth.yaml` content is stored in a Kubernetes Secret, since it commonly carries client secrets and other sensitive references.
+- Use `${ENV_VAR}` placeholders inside `auth.yaml` for any sensitive values and supply those variables through your existing Secret management flow (e.g. add `KC_CLIENT_SECRET` to the `fume-secrets` Secret).
+- If `auth.enabled=true`, do not set `env.AUTH_CONFIG_PATH` to a different path; the chart will fail fast on that conflict.
+- The designer's auth toggle is auto-coupled: when `auth.enabled=true`, `FUME_DESIGNER_AUTH_ENABLED=true` is injected automatically. To override, set `env.FUME_DESIGNER_AUTH_ENABLED` explicitly.
 
 ## Storage Configuration
 

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -10,6 +10,7 @@ This Helm chart deploys the FUME application stack on Kubernetes, including:
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
 - [Secrets and License Setup](#secrets-and-license-setup)
+- [Named FHIR Connections](#named-fhir-connections)
 - [Storage Configuration](#storage-configuration)
 - [Environment-Specific Deployments](#environment-specific-deployments)
 - [Upgrading](#upgrading)
@@ -253,6 +254,52 @@ secrets:
 image:
   pullSecret: "my-custom-dockerhub-secret"
 ```
+
+## Named FHIR Connections
+
+The chart can render a Secret-backed `connections.yml` and mount it into the backend automatically. When enabled, it also sets `FHIR_CONNECTIONS_FILE` to the mounted file path, so you do not need to add that environment variable yourself.
+
+Use a values file for the YAML payload instead of `--set`, because multiline connection configuration is awkward to manage on the command line.
+
+Example values file:
+
+```yaml
+fhirConnections:
+  enabled: true
+  mountPath: /usr/fume/connections.yml
+  yaml: |
+    fhir:
+      sandboxA:
+        baseUrl: https://sandbox-a.example.com/fhir
+        authType: BASIC
+        username: ${FHIR_SANDBOX_A_USERNAME}
+        password: ${FHIR_SANDBOX_A_PASSWORD}
+      sandboxB:
+        baseUrl: https://sandbox-b.example.com/fhir
+        authType: BASIC
+        username: ${FHIR_SANDBOX_B_USERNAME}
+        password: ${FHIR_SANDBOX_B_PASSWORD}
+
+env:
+  FHIR_CONNECTIONS_URL_POOL_SIZE: "50"
+```
+
+Deploy with the extra values file:
+
+```bash
+helm install fume ./helm/fume \
+  --namespace fume \
+  -f ./helm/fume/values.named-connections.yaml \
+  --set configMap.CANONICAL_BASE_URL="https://fume.your-company.com" \
+  --set configMap.FUME_SERVER_URL="https://your-fume-api.com" \
+  --set configMap.FHIR_PACKAGES="<org-specific-packages>"
+```
+
+Notes:
+- The chart stores this file in a Kubernetes Secret, not a ConfigMap, because connection files often contain credentials or secret placeholders.
+- You can keep sensitive values out of the authored YAML by using `${ENV_VAR}` placeholders and supplying those variables through your existing Secret management flow.
+- `env.FHIR_CONNECTIONS_URL_POOL_SIZE` remains the way to tune named-connection URL pooling.
+- If `fhirConnections.enabled=true`, do not set `env.FHIR_CONNECTIONS_FILE` to a different path; the chart will fail fast on that conflict.
 
 ## Storage Configuration
 

--- a/helm/fume/templates/_helpers.tpl
+++ b/helm/fume/templates/_helpers.tpl
@@ -70,6 +70,7 @@ Validate required configuration values
 	 Use local variable with default empty dict, then validate presence & non-empty value.
 */ -}}
 {{- $cfg := .Values.configMap | default dict -}}
+{{- $env := .Values.env | default dict -}}
 {{- if or (not (hasKey $cfg "CANONICAL_BASE_URL")) (eq (index $cfg "CANONICAL_BASE_URL") "") }}
 	{{- fail "CANONICAL_BASE_URL is required. Set via --set configMap.CANONICAL_BASE_URL=\"https://fume.your-company.com\"" }}
 {{- end }}
@@ -86,6 +87,17 @@ Validate required configuration values
 {{- end }}
 {{- if or (not .Values.secrets) (not .Values.secrets.license) }}
 	{{- fail "License secret name (.Values.secrets.license) is required. Ensure secret 'fume-license' exists or update values." }}
+{{- end }}
+{{- if .Values.fhirConnections.enabled }}
+{{- if eq (.Values.fhirConnections.mountPath | default "") "" }}
+	{{- fail "fhirConnections.mountPath is required when fhirConnections.enabled=true." }}
+{{- end }}
+{{- if eq (.Values.fhirConnections.yaml | default "") "" }}
+	{{- fail "fhirConnections.yaml is required when fhirConnections.enabled=true. Provide the raw connections.yml content with a top-level 'fhir:' key via a values file." }}
+{{- end }}
+{{- if and (hasKey $env "FHIR_CONNECTIONS_FILE") (ne (index $env "FHIR_CONNECTIONS_FILE") "") (ne (index $env "FHIR_CONNECTIONS_FILE") .Values.fhirConnections.mountPath) }}
+	{{- fail "env.FHIR_CONNECTIONS_FILE conflicts with fhirConnections.mountPath. Remove the env override or set it to the same path." }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm/fume/templates/_helpers.tpl
+++ b/helm/fume/templates/_helpers.tpl
@@ -99,6 +99,17 @@ Validate required configuration values
 	{{- fail "env.FHIR_CONNECTIONS_FILE conflicts with fhirConnections.mountPath. Remove the env override or set it to the same path." }}
 {{- end }}
 {{- end }}
+{{- if .Values.auth.enabled }}
+{{- if eq (.Values.auth.mountPath | default "") "" }}
+	{{- fail "auth.mountPath is required when auth.enabled=true." }}
+{{- end }}
+{{- if eq (.Values.auth.yaml | default "") "" }}
+	{{- fail "auth.yaml is required when auth.enabled=true. Provide the raw auth.yaml content (with top-level 'version: 1', 'keycloak:', 'policy:', ...) via a values file." }}
+{{- end }}
+{{- if and (hasKey $env "AUTH_CONFIG_PATH") (ne (index $env "AUTH_CONFIG_PATH") "") (ne (index $env "AUTH_CONFIG_PATH") .Values.auth.mountPath) }}
+	{{- fail "env.AUTH_CONFIG_PATH conflicts with auth.mountPath. Remove the env override or set it to the same path." }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/fume/templates/auth-secret.yaml
+++ b/helm/fume/templates/auth-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.auth.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fume.fullname" . }}-auth
+  labels:
+    {{- include "fume.labels" . | nindent 4 }}
+type: Opaque
+data:
+  auth.yaml: {{ .Values.auth.yaml | b64enc }}
+{{- end }}

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -20,6 +20,9 @@ spec:
         {{- if .Values.fhirConnections.enabled }}
         checksum/fhir-connections: {{ include (print $.Template.BasePath "/connections-secret.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth: {{ include (print $.Template.BasePath "/auth-secret.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
@@ -74,8 +77,12 @@ spec:
             - name: FHIR_CONNECTIONS_FILE
               value: {{ .Values.fhirConnections.mountPath | quote }}
             {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: AUTH_CONFIG_PATH
+              value: {{ .Values.auth.mountPath | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
-            {{- if and $value (or (ne $key "FHIR_CONNECTIONS_FILE") (not $.Values.fhirConnections.enabled)) }}
+            {{- if and $value (or (ne $key "FHIR_CONNECTIONS_FILE") (not $.Values.fhirConnections.enabled)) (or (ne $key "AUTH_CONFIG_PATH") (not $.Values.auth.enabled)) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -124,6 +131,12 @@ spec:
             - name: fhir-connections
               mountPath: {{ .Values.fhirConnections.mountPath }}
               subPath: connections.yml
+              readOnly: true
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: auth-config
+              mountPath: {{ .Values.auth.mountPath }}
+              subPath: auth.yaml
               readOnly: true
             {{- end }}
             {{- if .Values.tls.customCA.enabled }}
@@ -177,6 +190,14 @@ spec:
             items:
               - key: connections.yml
                 path: connections.yml
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        - name: auth-config
+          secret:
+            secretName: {{ include "fume.fullname" . }}-auth
+            items:
+              - key: auth.yaml
+                path: auth.yaml
         {{- end }}
         {{- if .Values.tls.customCA.enabled }}
         - name: custom-ca

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.fhirConnections.enabled }}
+        checksum/fhir-connections: {{ include (print $.Template.BasePath "/connections-secret.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "fume.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
@@ -67,8 +70,12 @@ spec:
             - name: MAPPINGS_FOLDER
               value: "/usr/fume/mappings"
             {{- end }}
+            {{- if .Values.fhirConnections.enabled }}
+            - name: FHIR_CONNECTIONS_FILE
+              value: {{ .Values.fhirConnections.mountPath | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
-            {{- if $value }}
+            {{- if and $value (or (ne $key "FHIR_CONNECTIONS_FILE") (not $.Values.fhirConnections.enabled)) }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
@@ -113,6 +120,12 @@ spec:
             - name: fhir-index
               mountPath: /usr/fume/fhirPackageIndex.json
               subPath: fhirPackageIndex.json
+            {{- if .Values.fhirConnections.enabled }}
+            - name: fhir-connections
+              mountPath: {{ .Values.fhirConnections.mountPath }}
+              subPath: connections.yml
+              readOnly: true
+            {{- end }}
             {{- if .Values.tls.customCA.enabled }}
             - name: custom-ca
               mountPath: {{ .Values.tls.customCA.mountPath }}
@@ -157,6 +170,14 @@ spec:
                 path: license.key.lic
         - name: fhir-index
           emptyDir: {}
+        {{- if .Values.fhirConnections.enabled }}
+        - name: fhir-connections
+          secret:
+            secretName: {{ include "fume.fullname" . }}-fhir-connections
+            items:
+              - key: connections.yml
+                path: connections.yml
+        {{- end }}
         {{- if .Values.tls.customCA.enabled }}
         - name: custom-ca
           secret:

--- a/helm/fume/templates/connections-secret.yaml
+++ b/helm/fume/templates/connections-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.fhirConnections.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fume.fullname" . }}-fhir-connections
+  labels:
+    {{- include "fume.labels" . | nindent 4 }}
+type: Opaque
+data:
+  connections.yml: {{ .Values.fhirConnections.yaml | b64enc }}
+{{- end }}

--- a/helm/fume/templates/frontend-deployment.yaml
+++ b/helm/fume/templates/frontend-deployment.yaml
@@ -66,6 +66,11 @@ spec:
             failureThreshold: {{ .Values.probes.frontend.readiness.failureThreshold }}
           {{- end }}
           env:
+            {{- $env := .Values.env | default dict }}
+            {{- if and .Values.auth.enabled (not (hasKey $env "FUME_DESIGNER_AUTH_ENABLED")) }}
+            - name: FUME_DESIGNER_AUTH_ENABLED
+              value: "true"
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             {{- if $value }}
             - name: {{ $key }}

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,10 +13,10 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "3.0.3"
+    tag: "3.1.0"
   frontend:
     repository: outburnltd/fume-designer
-    tag: "3.0.0"
+    tag: "3.1.0"
   pullPolicy: IfNotPresent
   pullSecret: ""  # Optional: set to a Secret name only if namespace/service account doesn't already provide pull access
 

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,7 +13,7 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "3.0.0"
+    tag: "3.0.3"
   frontend:
     repository: outburnltd/fume-designer
     tag: "3.0.0"

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -143,6 +143,15 @@ fhirConnections:
   mountPath: /usr/fume/connections.yml
   yaml: ""
 
+# Optional Secret-backed auth configuration file.
+# Provide the raw auth.yaml content (with top-level `version: 1`, `keycloak:`, `policy:`, ...) via a values file.
+# When enabled, the backend mounts this file and the chart sets AUTH_CONFIG_PATH to the mounted path.
+# It also enables auth on the designer by setting FUME_DESIGNER_AUTH_ENABLED=true (override via env if needed).
+auth:
+  enabled: false
+  mountPath: /usr/fume/auth.yaml
+  yaml: ""
+
 # Environment variables
 env:
   # Backend (FUME Engine) variables
@@ -152,6 +161,9 @@ env:
   
   # Frontend (FUME Designer) variables
   FUME_DESIGNER_HEADLINE: "FUME Designer"
+  # When auth.enabled=true, the chart auto-sets FUME_DESIGNER_AUTH_ENABLED=true on the designer.
+  # Uncomment to override that default (e.g. to keep the designer in public mode while the backend enforces auth).
+  # FUME_DESIGNER_AUTH_ENABLED: "false"
 
 # ConfigMap data (non-secret values)
 # Note: Required values must be provided during installation

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -136,6 +136,13 @@ secrets:
   # Optional secret key you may add to the fume-secrets Secret:
   # FHIR_PACKAGE_REGISTRY_TOKEN: <token> (used only when configMap.FHIR_PACKAGE_REGISTRY_URL is set)
 
+# Optional Secret-backed named FHIR connections file.
+# Provide the raw YAML document, including the top-level `fhir:` key, via a values file.
+fhirConnections:
+  enabled: false
+  mountPath: /usr/fume/connections.yml
+  yaml: ""
+
 # Environment variables
 env:
   # Backend (FUME Engine) variables


### PR DESCRIPTION
This pull request adds support for managing named FHIR connections via a Secret-backed `connections.yml` file in the FUME Helm chart, and adds matching support for a Secret-backed `auth.yaml` configuration consumed by both the backend (FUME Engine) and the frontend (FUME Designer). It introduces new configuration sections that allow users to define connection and auth details in YAML files, which are securely mounted into the relevant deployments. The implementation includes validation to prevent misconfiguration and updates the documentation to guide users through the new setup.

**Named FHIR Connections feature:**

* Added a new `fhirConnections` section in `values.yaml` to enable, configure the mount path, and provide the YAML content for named FHIR connections. The file is stored in a Kubernetes Secret and mounted into the backend container. (`helm/fume/values.yaml`, `helm/fume/templates/connections-secret.yaml`, [[1]](diffhunk://#diff-827b2f22d17ff7cbae8026b2a6b07a6a88bb6a8d8410ed789d5db6e1d101b6d5R139-R144) [[2]](diffhunk://#diff-f84460bec067dd0bec74ec91778212605c029ce011301b5eee8299d613d75848R1-R11))
* Updated backend deployment to mount the `connections.yml` Secret at the specified path, set the `FHIR_CONNECTIONS_FILE` environment variable automatically, and ensure the deployment is reloaded when the Secret changes. (`helm/fume/templates/backend-deployment.yaml`, [[1]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R20-R22) [[2]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R76-R78) [[3]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R130-R135) [[4]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R187-R193))

**Auth configuration feature:**

* Added a new `auth` section in `values.yaml` to enable, configure the mount path, and provide the YAML content for the backend's `auth.yaml`. The file is stored in a Kubernetes Secret and mounted into the backend container. (`helm/fume/values.yaml`, `helm/fume/templates/auth-secret.yaml`, [[1]](diffhunk://#diff-827b2f22d17ff7cbae8026b2a6b07a6a88bb6a8d8410ed789d5db6e1d101b6d5R146-R154) [[2]](diffhunk://#diff-a7e6cb200f15ee04711ee08f01d23d07520110189070735ca1aa890878d15592R1-R11))
* Updated backend deployment to mount the `auth.yaml` Secret at the specified path, set the `AUTH_CONFIG_PATH` environment variable automatically, and ensure the deployment is reloaded when the Secret changes. (`helm/fume/templates/backend-deployment.yaml`, [[1]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R23-R25) [[2]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R80-R83) [[3]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R136-R141) [[4]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724R193-R201))
* Updated frontend deployment to auto-set `FUME_DESIGNER_AUTH_ENABLED=true` when `auth.enabled=true`, so a single switch turns on auth for both apps. The default can still be overridden by setting `env.FUME_DESIGNER_AUTH_ENABLED` explicitly. (`helm/fume/templates/frontend-deployment.yaml`, `helm/fume/values.yaml`, [[1]](diffhunk://#diff-cbe0b6e80e8c7c852256a21e361e4f261ef2eded87d45e34180897915dedfb6dR69-R73) [[2]](diffhunk://#diff-827b2f22d17ff7cbae8026b2a6b07a6a88bb6a8d8410ed789d5db6e1d101b6d5R164-R166))

**Validation and conflict prevention:**

* Added Helm template logic to validate that when `fhirConnections.enabled` is true, both `mountPath` and `yaml` are provided, and to ensure `env.FHIR_CONNECTIONS_FILE` does not conflict with the configured mount path. (`helm/fume/templates/_helpers.tpl`, [helm/fume/templates/_helpers.tplR91-R101](diffhunk://#diff-31fbdf3185245b832d56379e7bada883dc00518f1b800c150405cd3794fb6e15R91-R101))
* Added equivalent validation for `auth.enabled`: both `mountPath` and `yaml` must be provided, and `env.AUTH_CONFIG_PATH` must not conflict with the configured mount path. (`helm/fume/templates/_helpers.tpl`, [helm/fume/templates/_helpers.tplR102-R112](diffhunk://#diff-31fbdf3185245b832d56379e7bada883dc00518f1b800c150405cd3794fb6e15R102-R112))
* Ensured the `\$env` variable is initialized to avoid nil map errors during validation. (`helm/fume/templates/_helpers.tpl`, [helm/fume/templates/_helpers.tplR73](diffhunk://#diff-31fbdf3185245b832d56379e7bada883dc00518f1b800c150405cd3794fb6e15R73))

**Documentation updates:**

* Updated the README to document the new Named FHIR Connections feature, including usage instructions, example values, and deployment notes. (`helm/fume/README.md`, [[1]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R13) [[2]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R258-R303))
* Added a new "Auth Configuration" section to the README with PKCE-mode and token-mediator-mode examples, describing the auto-coupling between `auth.enabled` and the designer's auth toggle. (`helm/fume/README.md`, [[1]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R14) [[2]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R304-R373))