### PR TITLE
Feat/v3.1.1 gap fill

### DIFF
--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 1.1.0
-appVersion: "3.1.0"
+version: 1.2.0
+appVersion: "3.1.1"
 maintainers:
   - name: Outburn Ltd.
 keywords:

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -614,6 +614,7 @@ env:
   SERVER_PORT: "42420"           # Port the engine exposes (default: 42420)
   FHIR_VERSION: "4.0.1"          # FHIR version (default: 4.0.1)
   FHIR_SERVER_AUTH_TYPE: "NONE"  # BASIC or NONE (default: NONE)
+  FUME_FILE_LOGGING: "false"     # Helm default: stdout-only logging in Kubernetes
 ```
 
 **Required ConfigMap values** (must be provided during deployment):
@@ -918,6 +919,9 @@ kubectl -n fume exec deploy/fume-backend -- printenv NODE_EXTRA_CA_CERTS
 
 ### Logs
 
+Backend file logging is disabled by default in this chart (`env.FUME_FILE_LOGGING=false`).
+Use Kubernetes/container logs as the primary operational source:
+
 ```bash
 # Backend logs
 kubectl logs -l app.kubernetes.io/component=backend --namespace fume -f
@@ -928,6 +932,8 @@ kubectl logs -l app.kubernetes.io/component=frontend --namespace fume -f
 # Previous container logs (if pod crashed)
 kubectl logs -l app.kubernetes.io/component=backend --namespace fume --previous
 ```
+
+If you explicitly override `env.FUME_FILE_LOGGING=true`, you must also mount writable storage for backend logs at `/usr/fume/logs` inside the backend container (the internal path is fixed). A typical approach is to add a PVC-backed `volume` plus a `volumeMount` with `mountPath: /usr/fume/logs` in your backend Deployment customization. This is usually not recommended for standard Kubernetes deployments where platform log aggregation already consumes stdout/stderr.
 
 
 ## Uninstalling

--- a/helm/fume/templates/backend-deployment.yaml
+++ b/helm/fume/templates/backend-deployment.yaml
@@ -103,8 +103,6 @@ spec:
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           volumeMounts:
-            - name: logs
-              mountPath: /usr/fume/logs
             - name: templates
               mountPath: /usr/fume/templates
             # Writable cache directory for FHIR packages (non-root friendly fixed path)
@@ -145,8 +143,6 @@ spec:
               readOnly: true
             {{- end }}
       volumes:
-        - name: logs
-          emptyDir: {}
         # templates: shared PVC (recommended) or emptyDir
         {{- if .Values.storage.templates.enabled }}
         - name: templates

--- a/helm/fume/values.schema.json
+++ b/helm/fume/values.schema.json
@@ -175,6 +175,12 @@
             "silent"
           ]
         },
+        "FUME_FILE_LOGGING": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
         "FUME_EVAL_THROW_LEVEL": {
           "type": "string",
           "pattern": "^[0-9]+$"

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -158,6 +158,9 @@ env:
   SERVER_PORT: "42420"
   FHIR_VERSION: "4.0.1"
   FHIR_SERVER_AUTH_TYPE: "NONE"  # BASIC or NONE
+  # Kubernetes default is stdout/stderr collection via kubectl logs or platform log aggregation.
+  # Disable backend rotating file logs by default in Helm deployments.
+  FUME_FILE_LOGGING: "false"
   
   # Frontend (FUME Designer) variables
   FUME_DESIGNER_HEADLINE: "FUME Designer"

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -13,10 +13,10 @@ enableFrontend: true
 image:
   backend:
     repository: outburnltd/fume-enterprise-server
-    tag: "3.1.0"
+    tag: "3.1.1"
   frontend:
     repository: outburnltd/fume-designer
-    tag: "3.1.0"
+    tag: "3.1.1"
   pullPolicy: IfNotPresent
   pullSecret: ""  # Optional: set to a Secret name only if namespace/service account doesn't already provide pull access
 


### PR DESCRIPTION
This pull request updates the FUME Helm chart to version 1.2.0, with a focus on improving logging practices for Kubernetes deployments. The main changes are the disabling of backend file logging by default (favoring stdout/stderr and Kubernetes log aggregation), updates to documentation to reflect this, and version bumps for both backend and frontend images. The chart and values files are also updated accordingly.

**Logging configuration improvements:**

* Backend file logging is now disabled by default in Helm deployments via the `FUME_FILE_LOGGING` environment variable (`FUME_FILE_LOGGING: "false"`). Documentation has been updated to explain this default and to guide users who wish to enable file logging, including the requirement to mount writable storage at `/usr/fume/logs` if file logging is enabled. (`[[1]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R617)`, `[[2]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R922-R924)`, `[[3]](diffhunk://#diff-cf29ea47506764a7db37cb3a2a2f2c1c6c201d3b114fff39f9ce7e641a0f21d4R936-R937)`, `[[4]](diffhunk://#diff-827b2f22d17ff7cbae8026b2a6b07a6a88bb6a8d8410ed789d5db6e1d101b6d5R161-R163)`)
* The backend deployment template no longer mounts an emptyDir volume for logs by default, aligning with the new logging approach. (`[[1]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724L106-L107)`, `[[2]](diffhunk://#diff-976379a906ef1a8d9a01805370d0ac808d946a3b72a134ec9074a5a5768f4724L148-L149)`)
* The chart’s values schema (`values.schema.json`) now supports the `FUME_FILE_LOGGING` variable as both string and boolean. (`[helm/fume/values.schema.jsonR178-R183](diffhunk://#diff-210a07e4ace39e24cf43aad07d806f634fdf5955026016fc2d56de918f3ec5edR178-R183)`)

**Chart and image version updates:**

* Chart version is bumped to `1.2.0`, and backend/frontend images are updated to `3.1.1`. (`[[1]](diffhunk://#diff-e2800baf6f8a11ae478139420d048cbed39fd4a225295e9b5ea2c5c4b10f38e9L5-R6)`, `[[2]](diffhunk://#diff-827b2f22d17ff7cbae8026b2a6b07a6a88bb6a8d8410ed789d5db6e1d101b6d5L16-R19)`)