### PR TITLE
docs: add designer cache refresh env var

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -91,3 +91,4 @@ These values are consumed by the Designer / browser.
 |---|---:|---|---:|---|
 | `FUME_SERVER_URL` | Yes | values.configMap | No | URL that the user's browser uses to call the backend API. Must be reachable from the user's network.
 | `FUME_DESIGNER_HEADLINE` | No | values.env | No | Cosmetic headline / environment marker.
+| `FUME_DESIGNER_CACHE_REFRESH_INTERVAL` | No | values.env | No | Refresh interval in seconds for the Designer's cached mappings and aliases. Default `30`. Set to `0` to disable periodic refresh.

--- a/helm/fume/Chart.yaml
+++ b/helm/fume/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fume
 description: A Helm chart for FUME Enterprise
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "3.1.1"
 maintainers:
   - name: Outburn Ltd.

--- a/helm/fume/README.md
+++ b/helm/fume/README.md
@@ -639,6 +639,7 @@ Non-secret environment variables (in `values.yaml`; override in `values.prod.yam
 ```yaml
 env:
   FUME_DESIGNER_HEADLINE: "FUME Designer - DEV"  # Page title/environment indicator
+  FUME_DESIGNER_CACHE_REFRESH_INTERVAL: "30"     # Refresh mappings and aliases every 30 seconds; use 0 to disable
 ```
 
 **Required ConfigMap values** (must be provided during deployment):

--- a/helm/fume/values.schema.json
+++ b/helm/fume/values.schema.json
@@ -243,6 +243,9 @@
         },
         "FUME_DESIGNER_HEADLINE": {
           "type": "string"
+          },
+          "FUME_DESIGNER_CACHE_REFRESH_INTERVAL": {
+            "type": "string"
         }
       },
       "additionalProperties": true

--- a/helm/fume/values.yaml
+++ b/helm/fume/values.yaml
@@ -164,6 +164,7 @@ env:
   
   # Frontend (FUME Designer) variables
   FUME_DESIGNER_HEADLINE: "FUME Designer"
+  FUME_DESIGNER_CACHE_REFRESH_INTERVAL: "30"
   # When auth.enabled=true, the chart auto-sets FUME_DESIGNER_AUTH_ENABLED=true on the designer.
   # Uncomment to override that default (e.g. to keep the designer in public mode while the backend enforces auth).
   # FUME_DESIGNER_AUTH_ENABLED: "false"


### PR DESCRIPTION
## Summary
Add `FUME_DESIGNER_CACHE_REFRESH_INTERVAL` to the Helm chart documentation and values surface for FUME Designer deployments.

## Changes
- document the variable in the environment variable inventory
- add the default value to `helm/fume/values.yaml`
- allow the variable in `helm/fume/values.schema.json`
- document Helm usage in the chart README
